### PR TITLE
improve package adoption: fix deps, add typing, coverage, and contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what went wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal code or CLI command to reproduce the issue.
+      placeholder: |
+        ```python
+        from healthcare_ai_guardrails import ...
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include the full traceback if applicable.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: Output of `python -c "import healthcare_ai_guardrails; print(healthcare_ai_guardrails.__version__)"`
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      description: Output of `python --version`
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Ubuntu 22.04, macOS 14, Windows 11"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature Request
+description: Suggest a new validator, API improvement, or other enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please describe the feature and its use case.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What limitation or gap in the current package is this addressing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature you would like. Include example YAML spec or Python API usage if applicable.
+      placeholder: |
+        ```yaml
+        input:
+          - type: my_new_check
+            name: example
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches you have thought about?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, references, or DICOM tags involved.
+    validations:
+      required: false

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     name: Python ${{ matrix.python-version }} tests
     steps:
       - uses: actions/checkout@v4
@@ -22,4 +22,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[test]
       - name: Run tests
-        run: pytest -q
+        run: pytest
+      - name: Upload coverage report
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Healthcare AI Guardrails
+
+Thank you for your interest in contributing! This document covers how to set up your development environment, add new validators, run tests, and submit pull requests.
+
+## Development setup
+
+Requires Python 3.9+. We recommend [uv](https://docs.astral.sh/uv/) for fast installs, but standard `pip` works fine too.
+
+```bash
+git clone https://github.com/SamPIngram/healthcare-ai-guardrails.git
+cd healthcare-ai-guardrails
+
+# With uv
+uv venv
+source .venv/bin/activate
+uv pip install -e .[dev]
+pre-commit install
+
+# With pip
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+pre-commit install
+```
+
+## Running tests
+
+```bash
+pytest
+```
+
+With coverage:
+
+```bash
+pytest --cov=healthcare_ai_guardrails --cov-report=term-missing
+```
+
+## Code style
+
+We use [black](https://black.readthedocs.io/) for formatting and [ruff](https://docs.astral.sh/ruff/) for linting. Both run automatically via pre-commit. To run them manually:
+
+```bash
+black .
+ruff check . --fix
+```
+
+Type checking with mypy:
+
+```bash
+mypy src
+```
+
+## Adding a new validator
+
+1. Add your validator class to the appropriate module under `src/healthcare_ai_guardrails/validators/`.
+2. Export it from `src/healthcare_ai_guardrails/__init__.py` and add it to `__all__`.
+3. Register a YAML `type` key for it in `src/healthcare_ai_guardrails/config.py` (`_build_validator`).
+4. Add at least one passing and one failing test in `tests/`.
+5. Add an example entry to `examples/spec.example.yaml` if it is a broadly applicable check.
+6. Update `README.md` (YAML Spec schema section) and `CHANGELOG.md`.
+
+### Synthetic DICOM in tests
+
+Use the `create_test_dicom` helper to generate in-memory DICOM datasets without needing real files:
+
+```python
+from healthcare_ai_guardrails.testing.dicom_factory import create_test_dicom
+
+ds = create_test_dicom(Modality="CT", PatientAge="045Y")
+```
+
+## Pull request checklist
+
+- [ ] Tests pass locally (`pytest`)
+- [ ] Code is formatted (`black .`) and lint-clean (`ruff check .`)
+- [ ] New public API is exported from `__init__.py`
+- [ ] New YAML spec type is documented in `README.md`
+- [ ] `CHANGELOG.md` has an entry under the upcoming version
+
+## Reporting issues
+
+Please use the GitHub issue templates — bug reports and feature requests each have a template to help provide the right information.
+
+## License
+
+By contributing you agree that your work will be licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Python Versions](https://img.shields.io/pypi/pyversions/healthcare-ai-guardrails.svg)
 ![CI](https://github.com/SamPIngram/healthcare-ai-guardrails/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/License-MIT-blue.svg)
+![Typed](https://img.shields.io/badge/typing-py.typed-informational)
 
 Lightweight validation guardrails for AI model inputs/outputs in healthcare workflows, with first-class DICOM support.
 
@@ -38,23 +39,26 @@ If you’re validating DICOM, `pydicom` and `numpy` are already included as depe
 
 ## Install (contributors)
 
-Dev install:
+Dev install (includes test, lint tools, and pre-commit):
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e .
+pip install -e .[dev]
+pre-commit install
 ```
 
 With uv (fast Python package manager):
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-# create and use a virtualenv automatically
 uv venv
 source .venv/bin/activate
-uv pip install -e .
+uv pip install -e .[dev]
+pre-commit install
 ```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for full contributor guidelines.
 
 ## Quick start
 
@@ -292,7 +296,7 @@ uv run black .
 
 ## Contributing
 
-PRs welcome. Please add/update tests for new validators or behavior and update `examples/spec.example.yaml` when adding new spec types.
+PRs welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions, how to add validators, and the PR checklist.
 
 To create DICOMs in tests, use `create_test_dicom` from `healthcare_ai_guardrails.testing.dicom_factory`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ where = ["src"]
 include = ["healthcare_ai_guardrails*"]
 exclude = []
 
+[tool.setuptools.package-data]
+healthcare_ai_guardrails = ["py.typed"]
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "-q --cov=healthcare_ai_guardrails --cov-report=term-missing --cov-report=xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ authors = [{ name = "Sam Ingram", email = "sampingram12@gmail.com" }]
 keywords = ["AI", "ML", "Healthcare", "DICOM", "Validation", "Guardrails"]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Healthcare Industry",
@@ -23,22 +28,28 @@ dependencies = [
     "PyYAML>=6.0",
     "jsonschema>=4.20",
     "numpy>=1.22",
-    "pre-commit>=4.3.0",
     "lxml>=6.0.2",
 ]
 
 [project.optional-dependencies]
 test = [
     "pytest>=8.4.2",
+    "pytest-cov>=5.0",
 ]
 lint = [
     "ruff",
     "black",
+    "mypy>=1.0",
+]
+dev = [
+    "healthcare-ai-guardrails[test,lint]",
+    "pre-commit>=4.3.0",
 ]
 
 [project.urls]
 Homepage = "https://github.com/SamPIngram/healthcare-ai-guardrails"
 Issues = "https://github.com/SamPIngram/healthcare-ai-guardrails/issues"
+Changelog = "https://github.com/SamPIngram/healthcare-ai-guardrails/blob/main/CHANGELOG.md"
 
 [project.scripts]
 hc-guardrails = "healthcare_ai_guardrails.cli:main"
@@ -53,5 +64,16 @@ exclude = []
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-q"
+addopts = "-q --cov=healthcare_ai_guardrails --cov-report=term-missing --cov-report=xml"
 testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["src/healthcare_ai_guardrails"]
+omit = ["*/testing/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]

--- a/src/healthcare_ai_guardrails/__init__.py
+++ b/src/healthcare_ai_guardrails/__init__.py
@@ -5,6 +5,13 @@ Exposes minimal public API for defining and running validation checks
 on inputs/outputs, with DICOM utilities.
 """
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("healthcare-ai-guardrails")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
+
 from .runner import GuardrailRunner, ValidationResult, Severity
 from .validators.basic import RangeCheck, ChoiceCheck, RequiredFieldsCheck
 from .validators.dicom import (
@@ -36,6 +43,7 @@ from .validators.hl7v3 import (
 from .config import load_spec
 
 __all__ = [
+    "__version__",
     "GuardrailRunner",
     "ValidationResult",
     "Severity",


### PR DESCRIPTION
- Remove pre-commit from hard user dependencies (move to optional [dev] group)
- Add mypy and pytest-cov to optional extras; add combined [dev] extra
- Add per-version Python classifiers (3.9–3.13) to pyproject.toml
- Add Changelog URL to project.urls
- Add py.typed marker for PEP 561 / mypy inline type support
- Expose __version__ via importlib.metadata in __init__.py
- Add Python 3.13 to CI test matrix (README already claimed it)
- Configure pytest-cov in pyproject.toml addopts; emit coverage.xml in CI
- Add CONTRIBUTING.md with setup, validator guide, and PR checklist
- Add GitHub issue templates for bug reports and feature requests
- Update README dev-install instructions and contributing section

https://claude.ai/code/session_01VNH1t6fMPZmW8iZiP7JgK1