### PR TITLE
feat: add MCP server exposing guardrails QA pipeline as AI-callable tools

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: Python ${{ matrix.python-version }} tests
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,9 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
-        language_version: python3
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+    rev: v0.15.6
     hooks:
       - id: ruff
         args: ["--fix"]
+      - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ output:
 
 ## Development
 
-Supported Python: 3.9–3.13 (tested in CI on Linux; library is pure Python and should work across platforms).
+Supported Python: 3.10–3.13 (tested in CI on Linux; library is pure Python and should work across platforms). Python 3.10 is the minimum due to the `mcp` dependency.
 
 Run tests locally:
 

--- a/README.md
+++ b/README.md
@@ -352,26 +352,21 @@ With uv:
 uv run pytest -q
 ```
 
-Lint/type-check (optional suggestions):
+Lint/format/type-check (optional suggestions):
 
 ```bash
 pip install ruff mypy
 ruff check .
+ruff format .
 mypy src
-```
-
-Code style:
-
-```bash
-pip install black
-black .
 ```
 
 With uv:
 
 ```bash
-uv pip install black
-uv run black .
+uv pip install ruff mypy
+uv run ruff check .
+uv run ruff format .
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Lightweight validation guardrails for AI model inputs/outputs in healthcare work
 - Output structure validation via JSON Schema
 - Simple Python API and CLI (`hc-guardrails`)
 - HL7 v2 support: basic field, value-in-list, regex, and numeric range checks via simple path syntax (e.g., PID-5.1)
- - HL7 v3 (XML) support: XPath-based validators for exists, value-in-list, regex, and numeric range with namespace support
+- HL7 v3 (XML) support: XPath-based validators for exists, value-in-list, regex, and numeric range with namespace support
+- **MCP server** (`hc-guardrails-mcp`): expose the full QA pipeline as tools for AI agents (Claude Desktop, Claude Code, etc.)
 
 ## Install (users)
 
@@ -142,6 +143,91 @@ hc-guardrails examples/tutorials/autocontouring_tutorial.yaml path/to/ct.dcm --m
 # Output (RTSTRUCT)
 hc-guardrails examples/tutorials/autocontouring_tutorial.yaml path/to/rs.dcm --mode output
 ```
+
+## MCP server (AI agent integration)
+
+The package ships a [Model Context Protocol](https://modelcontextprotocol.io) server so AI agents (Claude Desktop, Claude Code, any MCP-compatible client) can run the guardrails QA pipeline automatically.
+
+### Setup
+
+The `hc-guardrails-mcp` command is installed alongside the package:
+
+```bash
+pip install healthcare-ai-guardrails
+```
+
+Configure it as a stdio MCP server in your client. For **Claude Desktop**, add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "healthcare-guardrails": {
+      "command": "hc-guardrails-mcp"
+    }
+  }
+}
+```
+
+For **Claude Code**:
+
+```bash
+claude mcp add healthcare-guardrails hc-guardrails-mcp
+```
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `run_guardrails` | Run all validators from a spec against a data file or inline content. Returns per-validator pass/fail results and a summary. |
+| `list_validator_types` | Return the full catalog of available validator types, grouped by category, with their parameters. Useful for building new specs. |
+| `validate_spec` | Parse a YAML spec and report any configuration errors (unknown types, YAML syntax problems) before running it on real data. |
+| `describe_spec` | Load a spec and return a human-readable description of what each validator checks (name, description, severity). |
+
+### Example: run guardrails from a spec file
+
+```
+Tool: run_guardrails
+  spec_path: /data/ct_input_spec.yaml
+  data_path:  /data/patient001.dcm
+  mode:       input
+```
+
+Response:
+```json
+{
+  "summary": { "total": 5, "passed": 4, "failed": 1, "all_passed": false },
+  "results": [
+    { "name": "modality_check", "passed": true,  "message": "", "severity": "warning" },
+    { "name": "age_range",      "passed": true,  "message": "", "severity": "warning" },
+    { "name": "slice_thickness","passed": false, "message": "2.5 > max 2.0", "severity": "error" },
+    ...
+  ]
+}
+```
+
+### Example: run guardrails with an inline spec and JSON data
+
+```
+Tool: run_guardrails
+  spec_yaml: |
+    input:
+      - type: range
+        name: probability_range
+        path: ["probability"]
+        min: 0.0
+        max: 1.0
+  data_content: '{"probability": 0.7}'
+  mode: input
+```
+
+### Data formats supported
+
+| Format | Via `data_path` | Via `data_content` |
+|---|---|---|
+| DICOM (`.dcm`) | Yes | No (binary) |
+| JSON | Yes | Yes |
+| HL7 v2 | Yes | Yes (auto-detected by `MSH` prefix) |
+| HL7 v3 / XML | Yes | Yes (auto-detected by `<` prefix) |
 
 ## Python API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ test = [
 ]
 lint = [
     "ruff",
-    "black",
     "mypy>=1.0",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "jsonschema>=4.20",
     "numpy>=1.22",
     "lxml>=6.0.2",
-    "mcp>=1.0",
+    "mcp>=1.26.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ name = "healthcare-ai-guardrails"
 version = "0.4.0"
 description = "Guardrails for AI input/output validation in healthcare, with DICOM support"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Sam Ingram", email = "sampingram12@gmail.com" }]
 keywords = ["AI", "ML", "Healthcare", "DICOM", "Validation", "Guardrails"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "jsonschema>=4.20",
     "numpy>=1.22",
     "lxml>=6.0.2",
+    "mcp>=1.0",
 ]
 
 [project.optional-dependencies]
@@ -53,6 +54,7 @@ Changelog = "https://github.com/SamPIngram/healthcare-ai-guardrails/blob/main/CH
 
 [project.scripts]
 hc-guardrails = "healthcare_ai_guardrails.cli:main"
+hc-guardrails-mcp = "healthcare_ai_guardrails.mcp_server:main"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/healthcare_ai_guardrails/__init__.py
+++ b/src/healthcare_ai_guardrails/__init__.py
@@ -40,7 +40,7 @@ from .validators.hl7v3 import (
     HL7v3XPathRegexMatchCheck,
     HL7v3XPathNumericRangeCheck,
 )
-from .config import load_spec
+from .config import load_spec, load_spec_from_string
 
 __all__ = [
     "__version__",
@@ -71,4 +71,5 @@ __all__ = [
     "HL7v3XPathRegexMatchCheck",
     "HL7v3XPathNumericRangeCheck",
     "load_spec",
+    "load_spec_from_string",
 ]

--- a/src/healthcare_ai_guardrails/_io.py
+++ b/src/healthcare_ai_guardrails/_io.py
@@ -11,7 +11,7 @@ def _read_dicom(path: Path) -> Any:
 
         return pydicom.dcmread(str(path))
     except Exception as exc:
-        raise SystemExit(f"Failed to read DICOM: {exc}")
+        raise ValueError(f"Failed to read DICOM: {exc}") from exc
 
 
 def _read_json(path: Path) -> Any:
@@ -33,7 +33,7 @@ def _read_xml(path: Path) -> Any:
         tree = ET.parse(str(path))
         return tree.getroot()
     except Exception as exc:
-        raise SystemExit(f"Failed to read XML: {exc}")
+        raise ValueError(f"Failed to read XML: {exc}") from exc
 
 
 def load_data_from_path(path: Path) -> Any:

--- a/src/healthcare_ai_guardrails/_io.py
+++ b/src/healthcare_ai_guardrails/_io.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _read_dicom(path: Path) -> Any:
+    try:
+        import pydicom
+
+        return pydicom.dcmread(str(path))
+    except Exception as exc:
+        raise SystemExit(f"Failed to read DICOM: {exc}")
+
+
+def _read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _read_text(path: Path) -> str:
+    with path.open("r", encoding="utf-8", errors="ignore") as f:
+        return f.read()
+
+
+def _read_xml(path: Path) -> Any:
+    try:
+        try:
+            from lxml import etree as ET  # type: ignore
+        except Exception:  # pragma: no cover
+            import xml.etree.ElementTree as ET  # type: ignore
+        tree = ET.parse(str(path))
+        return tree.getroot()
+    except Exception as exc:
+        raise SystemExit(f"Failed to read XML: {exc}")
+
+
+def load_data_from_path(path: Path) -> Any:
+    """Detect data format from file extension and load accordingly."""
+    if path.suffix.lower() in {".dcm", ".dicom"}:
+        return _read_dicom(path)
+    elif path.suffix.lower() in {".json"}:
+        return _read_json(path)
+    elif path.suffix.lower() in {".xml"}:
+        return _read_xml(path)
+    else:
+        text = _read_text(path)
+        if text.strip().startswith("MSH"):
+            return text
+        try:
+            return json.loads(text)
+        except Exception:
+            return text
+
+
+def load_data_from_string(content: str) -> Any:
+    """Detect data format from inline content and parse accordingly."""
+    stripped = content.strip()
+    if stripped.startswith("MSH"):
+        return content
+    if stripped.startswith("<"):
+        try:
+            from lxml import etree as ET  # type: ignore
+        except Exception:  # pragma: no cover
+            import xml.etree.ElementTree as ET  # type: ignore
+        return ET.fromstring(stripped.encode())
+    try:
+        return json.loads(content)
+    except Exception:
+        return content

--- a/src/healthcare_ai_guardrails/cli.py
+++ b/src/healthcare_ai_guardrails/cli.py
@@ -20,7 +20,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     spec = load_spec(args.spec)
-    data = load_data_from_path(Path(args.data))
+    try:
+        data = load_data_from_path(Path(args.data))
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     validators = (
         spec.input_validators if args.mode == "input" else spec.output_validators

--- a/src/healthcare_ai_guardrails/cli.py
+++ b/src/healthcare_ai_guardrails/cli.py
@@ -1,45 +1,11 @@
 from __future__ import annotations
 
 import argparse
-import json
 from pathlib import Path
-from typing import Any
 
+from ._io import load_data_from_path
 from .config import load_spec
 from .runner import GuardrailRunner
-
-
-def _read_dicom(path: Path) -> Any:
-    try:
-        import pydicom
-
-        return pydicom.dcmread(str(path))
-    except Exception as exc:
-        raise SystemExit(f"Failed to read DICOM: {exc}")
-
-
-def _read_json(path: Path) -> Any:
-    with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
-
-
-def _read_text(path: Path) -> str:
-    with path.open("r", encoding="utf-8", errors="ignore") as f:
-        return f.read()
-
-
-def _read_xml(path: Path) -> Any:
-    try:
-        # Prefer lxml if available
-        try:
-            from lxml import etree as ET  # type: ignore
-        except Exception:  # pragma: no cover
-            import xml.etree.ElementTree as ET  # type: ignore
-        tree = ET.parse(str(path))
-        # For lxml, pass the root Element (supports rich xpath); for stdlib, ElementTree works with .findall
-        return tree.getroot()
-    except Exception as exc:
-        raise SystemExit(f"Failed to read XML: {exc}")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -54,24 +20,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     spec = load_spec(args.spec)
-    data_path = Path(args.data)
-    if data_path.suffix.lower() in {".dcm", ".dicom"}:
-        data = _read_dicom(data_path)
-    elif data_path.suffix.lower() in {".json"}:
-        data = _read_json(data_path)
-    elif data_path.suffix.lower() in {".xml"}:
-        data = _read_xml(data_path)
-    else:
-        # Try HL7 v2 text files (.hl7 or no extension) or fall back to raw text
-        text = _read_text(data_path)
-        if text.strip().startswith("MSH"):
-            data = text  # HL7 v2 message string
-        else:
-            # Fallback: attempt JSON parse, else keep as raw text
-            try:
-                data = json.loads(text)
-            except Exception:
-                data = text
+    data = load_data_from_path(Path(args.data))
 
     validators = (
         spec.input_validators if args.mode == "input" else spec.output_validators

--- a/src/healthcare_ai_guardrails/config.py
+++ b/src/healthcare_ai_guardrails/config.py
@@ -337,12 +337,22 @@ def _build_validator(entry: Dict[str, Any]) -> ValidatorObj:
     raise ValueError(f"Unknown validator type: {t}")
 
 
-def load_spec(path: str | Path) -> Spec:
-    p = Path(path)
-    with p.open("r", encoding="utf-8") as f:
-        cfg = yaml.safe_load(f) or {}
+def _build_spec_from_dict(cfg: Dict[str, Any]) -> Spec:
     input_entries = cfg.get("input", [])
     output_entries = cfg.get("output", [])
     input_validators = [_build_validator(e) for e in input_entries]
     output_validators = [_build_validator(e) for e in output_entries]
     return Spec(input_validators=input_validators, output_validators=output_validators)
+
+
+def load_spec(path: str | Path) -> Spec:
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+    return _build_spec_from_dict(cfg)
+
+
+def load_spec_from_string(yaml_content: str) -> Spec:
+    """Load a guardrail spec from a YAML string rather than a file path."""
+    cfg = yaml.safe_load(yaml_content) or {}
+    return _build_spec_from_dict(cfg)

--- a/src/healthcare_ai_guardrails/config.py
+++ b/src/healthcare_ai_guardrails/config.py
@@ -45,7 +45,6 @@ from .validators.hl7v3 import (
     HL7v3XPathNumericRangeCheck,
 )
 
-
 ValidatorObj = Any
 
 

--- a/src/healthcare_ai_guardrails/mcp_server.py
+++ b/src/healthcare_ai_guardrails/mcp_server.py
@@ -1,0 +1,460 @@
+"""MCP server exposing the healthcare-ai-guardrails QA pipeline as tools.
+
+Run with:
+    hc-guardrails-mcp
+    # or
+    python -m healthcare_ai_guardrails.mcp_server
+
+Configure in Claude Desktop / MCP Inspector as a stdio server.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+from mcp.server.fastmcp import FastMCP
+
+from ._io import load_data_from_path, load_data_from_string
+from .config import load_spec, load_spec_from_string
+from .runner import GuardrailRunner
+
+mcp = FastMCP("healthcare-ai-guardrails")
+
+# ---------------------------------------------------------------------------
+# Validator type catalog (used by list_validator_types)
+# ---------------------------------------------------------------------------
+
+_VALIDATOR_CATALOG: List[Dict[str, Any]] = [
+    # Generic
+    {
+        "category": "generic",
+        "type": "range",
+        "description": "Checks that a numeric field at a given JSON path falls within [min, max].",
+        "required_params": ["path"],
+        "optional_params": ["min", "max", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "generic",
+        "type": "choice",
+        "description": "Checks that a field at a given JSON path is one of the allowed values.",
+        "required_params": ["path", "allowed"],
+        "optional_params": ["case_insensitive", "name", "severity", "description"],
+    },
+    {
+        "category": "generic",
+        "type": "required_fields",
+        "description": "Checks that a set of JSON paths are all present and non-null.",
+        "required_params": ["paths"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "generic",
+        "type": "json_schema",
+        "description": "Validates data against a JSON Schema (Draft 2020-12).",
+        "required_params": ["schema"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    # DICOM
+    {
+        "category": "dicom",
+        "type": "dicom_patient_age",
+        "description": "Checks patient age is within a year range. Parses age strings (e.g. '045Y', '008M') and birthdate fallback.",
+        "required_params": [],
+        "optional_params": ["min_years", "max_years", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_modality",
+        "description": "Checks that the DICOM Modality tag is in the allowed list (e.g. CT, MR, US).",
+        "required_params": ["allowed"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_patient_sex",
+        "description": "Checks that PatientSex is in the allowed list (default: M, F, O).",
+        "required_params": [],
+        "optional_params": ["allowed", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_patient_position",
+        "description": "Checks that PatientPosition is in the allowed list (e.g. HFS, FFP).",
+        "required_params": ["allowed"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_slice_thickness",
+        "description": "Checks that SliceThickness (mm) is within [min_mm, max_mm].",
+        "required_params": [],
+        "optional_params": ["min_mm", "max_mm", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_pixel_spacing",
+        "description": "Checks that both PixelSpacing values (mm) are within [min_mm, max_mm].",
+        "required_params": [],
+        "optional_params": ["min_mm", "max_mm", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_image_orientation",
+        "description": "Checks that ImageOrientationPatient vectors are orthogonal (dot product near zero).",
+        "required_params": [],
+        "optional_params": ["tolerance", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_sop_class",
+        "description": "Checks that the SOPClassUID is in the allowed list of UIDs.",
+        "required_params": ["allowed"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_body_part_examined",
+        "description": "Checks that BodyPartExamined is in the allowed list.",
+        "required_params": ["allowed"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_photometric_interpretation",
+        "description": "Checks that PhotometricInterpretation is in the allowed list (e.g. MONOCHROME2, RGB).",
+        "required_params": ["allowed"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_pixel_intensity_range",
+        "description": "Checks that all pixel intensity values fall within [min, max].",
+        "required_params": [],
+        "optional_params": ["min", "max", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_protocol_name",
+        "description": "Checks that ProtocolName is in the allowed list.",
+        "required_params": ["allowed"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_rt_structure",
+        "description": "Checks that required ROI names are present in an RT Structure Set.",
+        "required_params": ["required_rois"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_kvp",
+        "description": "Checks that X-ray tube voltage KVP is within [min_kvp, max_kvp].",
+        "required_params": [],
+        "optional_params": ["min_kvp", "max_kvp", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_tube_current",
+        "description": "Checks that X-ray tube current (mA) is within [min_ma, max_ma].",
+        "required_params": [],
+        "optional_params": ["min_ma", "max_ma", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom",
+        "type": "dicom_exposure_time",
+        "description": "Checks that X-ray exposure time (ms) is within [min_ms, max_ms].",
+        "required_params": [],
+        "optional_params": ["min_ms", "max_ms", "inclusive", "name", "severity", "description"],
+    },
+    # DICOM generic
+    {
+        "category": "dicom_generic",
+        "type": "dicom_generic_numeric_range",
+        "description": "Generic numeric range check on any DICOM tag by name.",
+        "required_params": ["tag"],
+        "optional_params": ["unit", "min_val", "max_val", "inclusive", "name", "severity", "description"],
+    },
+    {
+        "category": "dicom_generic",
+        "type": "dicom_generic_value_in_list",
+        "description": "Generic value-in-list check on any DICOM tag by name.",
+        "required_params": ["tag", "allowed_values"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "dicom_generic",
+        "type": "dicom_generic_tag_type_check",
+        "description": "Checks that a DICOM tag has the expected Value Representation (VR) type.",
+        "required_params": ["tag", "expected_vr"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    # HL7 v2
+    {
+        "category": "hl7v2",
+        "type": "hl7v2_field_exists",
+        "description": "Checks that a field at an HL7 v2 path (e.g. PID-5.1) is present and non-empty.",
+        "required_params": ["path"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "hl7v2",
+        "type": "hl7v2_value_in_list",
+        "description": "Checks that a field at an HL7 v2 path is one of the allowed values.",
+        "required_params": ["path", "allowed"],
+        "optional_params": ["case_insensitive", "name", "severity", "description"],
+    },
+    {
+        "category": "hl7v2",
+        "type": "hl7v2_regex_match",
+        "description": "Checks that a field at an HL7 v2 path matches a regex pattern.",
+        "required_params": ["path", "pattern"],
+        "optional_params": ["name", "severity", "description"],
+    },
+    {
+        "category": "hl7v2",
+        "type": "hl7v2_numeric_range",
+        "description": "Checks that a numeric field at an HL7 v2 path is within [min, max].",
+        "required_params": ["path"],
+        "optional_params": ["min", "max", "inclusive", "name", "severity", "description"],
+    },
+    # HL7 v3 (XML/CDA)
+    {
+        "category": "hl7v3",
+        "type": "hl7v3_xpath_exists",
+        "description": "Checks that an XPath expression selects at least one node in HL7 v3 XML.",
+        "required_params": ["xpath"],
+        "optional_params": ["namespaces", "name", "severity", "description"],
+    },
+    {
+        "category": "hl7v3",
+        "type": "hl7v3_xpath_value_in_list",
+        "description": "Checks that the value at an XPath expression is in the allowed list.",
+        "required_params": ["xpath", "allowed"],
+        "optional_params": ["namespaces", "attr", "case_insensitive", "name", "severity", "description"],
+    },
+    {
+        "category": "hl7v3",
+        "type": "hl7v3_xpath_regex_match",
+        "description": "Checks that the value at an XPath expression matches a regex pattern.",
+        "required_params": ["xpath", "pattern"],
+        "optional_params": ["namespaces", "attr", "name", "severity", "description"],
+    },
+    {
+        "category": "hl7v3",
+        "type": "hl7v3_xpath_numeric_range",
+        "description": "Checks that a numeric value at an XPath expression is within [min, max].",
+        "required_params": ["xpath"],
+        "optional_params": ["min", "max", "inclusive", "namespaces", "attr", "name", "severity", "description"],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _result_to_dict(r: Any) -> Dict[str, Any]:
+    return {
+        "name": r.name,
+        "passed": r.passed,
+        "message": r.message,
+        "severity": r.severity.value if hasattr(r.severity, "value") else str(r.severity),
+        "context": r.context if r.context else {},
+    }
+
+
+def _load_spec_from_args(spec_path: Optional[str], spec_yaml: Optional[str]) -> Any:
+    if spec_path and spec_yaml:
+        raise ValueError("Provide spec_path or spec_yaml, not both.")
+    if spec_path:
+        return load_spec(spec_path)
+    if spec_yaml:
+        return load_spec_from_string(spec_yaml)
+    raise ValueError("One of spec_path or spec_yaml is required.")
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def run_guardrails(
+    mode: str = "input",
+    spec_path: Optional[str] = None,
+    spec_yaml: Optional[str] = None,
+    data_path: Optional[str] = None,
+    data_content: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run healthcare guardrail validators on a data file or inline content.
+
+    Provide the spec as a file path (spec_path) or inline YAML string (spec_yaml).
+    Provide the data as a file path (data_path) or inline text (data_content).
+    DICOM files must use data_path. JSON, HL7, and XML can use either.
+
+    Args:
+        mode: Which validators to run — "input" or "output". Default "input".
+        spec_path: Path to a YAML guardrail spec file on disk.
+        spec_yaml: Inline YAML spec content as a string.
+        data_path: Path to a data file (.dcm, .json, .xml, .hl7, etc.).
+        data_content: Inline data — JSON string, HL7 v2 message, or XML text.
+
+    Returns:
+        Dict with "summary" (total/passed/failed/all_passed) and "results"
+        (list of per-validator outcomes with name, passed, message, severity, context).
+    """
+    if not data_path and not data_content:
+        return {"error": "One of data_path or data_content is required."}
+
+    try:
+        spec = _load_spec_from_args(spec_path, spec_yaml)
+    except Exception as exc:
+        return {"error": f"Failed to load spec: {exc}"}
+
+    try:
+        if data_path:
+            data = load_data_from_path(Path(data_path))
+        else:
+            data = load_data_from_string(data_content)  # type: ignore[arg-type]
+    except Exception as exc:
+        return {"error": f"Failed to load data: {exc}"}
+
+    validators = spec.input_validators if mode == "input" else spec.output_validators
+    runner = GuardrailRunner(validators)
+    results = runner.run(data)
+
+    result_dicts = [_result_to_dict(r) for r in results]
+    passed_count = sum(1 for r in results if r.passed)
+    total = len(results)
+
+    return {
+        "summary": {
+            "total": total,
+            "passed": passed_count,
+            "failed": total - passed_count,
+            "all_passed": passed_count == total,
+        },
+        "results": result_dicts,
+    }
+
+
+@mcp.tool()
+def list_validator_types() -> Dict[str, Any]:
+    """List all available guardrail validator types with their parameters.
+
+    Returns a catalog of every validator type that can be used in a YAML spec,
+    grouped by category (generic, dicom, dicom_generic, hl7v2, hl7v3).
+    Includes each type's description and required/optional parameters.
+
+    Returns:
+        Dict with "validators" list and "categories" summary.
+    """
+    categories: Dict[str, List[str]] = {}
+    for v in _VALIDATOR_CATALOG:
+        cat = v["category"]
+        categories.setdefault(cat, []).append(v["type"])
+
+    return {
+        "validators": _VALIDATOR_CATALOG,
+        "categories": categories,
+        "total": len(_VALIDATOR_CATALOG),
+    }
+
+
+@mcp.tool()
+def validate_spec(
+    spec_path: Optional[str] = None,
+    spec_yaml: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Validate a guardrail YAML spec for correctness before running it.
+
+    Attempts to parse and instantiate all validators defined in the spec.
+    Returns errors for unknown validator types, missing required parameters,
+    or YAML syntax problems.
+
+    Args:
+        spec_path: Path to a YAML guardrail spec file on disk.
+        spec_yaml: Inline YAML spec content as a string.
+
+    Returns:
+        Dict with "valid" (bool), "errors" (list of strings),
+        "input_count" and "output_count" (number of validators per section).
+    """
+    errors: List[str] = []
+
+    try:
+        spec = _load_spec_from_args(spec_path, spec_yaml)
+        return {
+            "valid": True,
+            "errors": [],
+            "input_count": len(spec.input_validators),
+            "output_count": len(spec.output_validators),
+        }
+    except yaml.YAMLError as exc:
+        errors.append(f"YAML syntax error: {exc}")
+    except ValueError as exc:
+        errors.append(str(exc))
+    except Exception as exc:
+        errors.append(f"Unexpected error: {exc}")
+
+    return {"valid": False, "errors": errors, "input_count": 0, "output_count": 0}
+
+
+@mcp.tool()
+def describe_spec(
+    spec_path: Optional[str] = None,
+    spec_yaml: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Parse a guardrail spec and describe what each validator checks.
+
+    Loads the spec and introspects each validator's name, description, and
+    severity so an AI can understand what a spec does before running it.
+
+    Args:
+        spec_path: Path to a YAML guardrail spec file on disk.
+        spec_yaml: Inline YAML spec content as a string.
+
+    Returns:
+        Dict with "input_validators" and "output_validators" lists, each
+        containing {name, description, severity} for every validator.
+    """
+    try:
+        spec = _load_spec_from_args(spec_path, spec_yaml)
+    except Exception as exc:
+        return {"error": f"Failed to load spec: {exc}"}
+
+    def _describe(validators: List[Any]) -> List[Dict[str, str]]:
+        out = []
+        for v in validators:
+            severity_val = (
+                v.severity.value if hasattr(v.severity, "value") else str(v.severity)
+            )
+            out.append(
+                {
+                    "name": getattr(v, "name", ""),
+                    "description": getattr(v, "description", ""),
+                    "severity": severity_val,
+                    "validator_class": type(v).__name__,
+                }
+            )
+        return out
+
+    return {
+        "input_validators": _describe(spec.input_validators),
+        "output_validators": _describe(spec.output_validators),
+        "input_count": len(spec.input_validators),
+        "output_count": len(spec.output_validators),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:  # pragma: no cover
+    mcp.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/healthcare_ai_guardrails/mcp_server.py
+++ b/src/healthcare_ai_guardrails/mcp_server.py
@@ -304,6 +304,8 @@ def run_guardrails(
         Dict with "summary" (total/passed/failed/all_passed) and "results"
         (list of per-validator outcomes with name, passed, message, severity, context).
     """
+    if mode not in {"input", "output"}:
+        return {"error": f"Invalid mode {mode!r}. Must be 'input' or 'output'."}
     if not data_path and not data_content:
         return {"error": "One of data_path or data_content is required."}
 
@@ -417,7 +419,7 @@ def describe_spec(
 
     Returns:
         Dict with "input_validators" and "output_validators" lists, each
-        containing {name, description, severity} for every validator.
+        containing {name, description, severity, validator_class} for every validator.
     """
     try:
         spec = _load_spec_from_args(spec_path, spec_yaml)

--- a/src/healthcare_ai_guardrails/mcp_server.py
+++ b/src/healthcare_ai_guardrails/mcp_server.py
@@ -7,6 +7,7 @@ Run with:
 
 Configure in Claude Desktop / MCP Inspector as a stdio server.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -32,7 +33,14 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "range",
         "description": "Checks that a numeric field at a given JSON path falls within [min, max].",
         "required_params": ["path"],
-        "optional_params": ["min", "max", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min",
+            "max",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "generic",
@@ -61,7 +69,14 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "dicom_patient_age",
         "description": "Checks patient age is within a year range. Parses age strings (e.g. '045Y', '008M') and birthdate fallback.",
         "required_params": [],
-        "optional_params": ["min_years", "max_years", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min_years",
+            "max_years",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "dicom",
@@ -89,14 +104,28 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "dicom_slice_thickness",
         "description": "Checks that SliceThickness (mm) is within [min_mm, max_mm].",
         "required_params": [],
-        "optional_params": ["min_mm", "max_mm", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min_mm",
+            "max_mm",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "dicom",
         "type": "dicom_pixel_spacing",
         "description": "Checks that both PixelSpacing values (mm) are within [min_mm, max_mm].",
         "required_params": [],
-        "optional_params": ["min_mm", "max_mm", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min_mm",
+            "max_mm",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "dicom",
@@ -131,7 +160,14 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "dicom_pixel_intensity_range",
         "description": "Checks that all pixel intensity values fall within [min, max].",
         "required_params": [],
-        "optional_params": ["min", "max", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min",
+            "max",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "dicom",
@@ -152,21 +188,42 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "dicom_kvp",
         "description": "Checks that X-ray tube voltage KVP is within [min_kvp, max_kvp].",
         "required_params": [],
-        "optional_params": ["min_kvp", "max_kvp", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min_kvp",
+            "max_kvp",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "dicom",
         "type": "dicom_tube_current",
         "description": "Checks that X-ray tube current (mA) is within [min_ma, max_ma].",
         "required_params": [],
-        "optional_params": ["min_ma", "max_ma", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min_ma",
+            "max_ma",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "dicom",
         "type": "dicom_exposure_time",
         "description": "Checks that X-ray exposure time (ms) is within [min_ms, max_ms].",
         "required_params": [],
-        "optional_params": ["min_ms", "max_ms", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min_ms",
+            "max_ms",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     # DICOM generic
     {
@@ -174,7 +231,15 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "dicom_generic_numeric_range",
         "description": "Generic numeric range check on any DICOM tag by name.",
         "required_params": ["tag"],
-        "optional_params": ["unit", "min_val", "max_val", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "unit",
+            "min_val",
+            "max_val",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "dicom_generic",
@@ -217,7 +282,14 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "hl7v2_numeric_range",
         "description": "Checks that a numeric field at an HL7 v2 path is within [min, max].",
         "required_params": ["path"],
-        "optional_params": ["min", "max", "inclusive", "name", "severity", "description"],
+        "optional_params": [
+            "min",
+            "max",
+            "inclusive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     # HL7 v3 (XML/CDA)
     {
@@ -232,7 +304,14 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "hl7v3_xpath_value_in_list",
         "description": "Checks that the value at an XPath expression is in the allowed list.",
         "required_params": ["xpath", "allowed"],
-        "optional_params": ["namespaces", "attr", "case_insensitive", "name", "severity", "description"],
+        "optional_params": [
+            "namespaces",
+            "attr",
+            "case_insensitive",
+            "name",
+            "severity",
+            "description",
+        ],
     },
     {
         "category": "hl7v3",
@@ -246,7 +325,16 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
         "type": "hl7v3_xpath_numeric_range",
         "description": "Checks that a numeric value at an XPath expression is within [min, max].",
         "required_params": ["xpath"],
-        "optional_params": ["min", "max", "inclusive", "namespaces", "attr", "name", "severity", "description"],
+        "optional_params": [
+            "min",
+            "max",
+            "inclusive",
+            "namespaces",
+            "attr",
+            "name",
+            "severity",
+            "description",
+        ],
     },
 ]
 
@@ -255,12 +343,15 @@ _VALIDATOR_CATALOG: List[Dict[str, Any]] = [
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _result_to_dict(r: Any) -> Dict[str, Any]:
     return {
         "name": r.name,
         "passed": r.passed,
         "message": r.message,
-        "severity": r.severity.value if hasattr(r.severity, "value") else str(r.severity),
+        "severity": (
+            r.severity.value if hasattr(r.severity, "value") else str(r.severity)
+        ),
         "context": r.context if r.context else {},
     }
 
@@ -278,6 +369,7 @@ def _load_spec_from_args(spec_path: Optional[str], spec_yaml: Optional[str]) -> 
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
+
 
 @mcp.tool()
 def run_guardrails(
@@ -453,6 +545,7 @@ def describe_spec(
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:  # pragma: no cover
     mcp.run()

--- a/src/healthcare_ai_guardrails/validators/hl7v3.py
+++ b/src/healthcare_ai_guardrails/validators/hl7v3.py
@@ -198,9 +198,7 @@ class HL7v3XPathNumericRangeCheck:
     attr: str | None = None
     name: str = "hl7v3_xpath_numeric_range"
     severity: Severity = Severity.WARNING
-    description: str = (
-        "Ensure the XPath-selected value (attribute or text) is numeric and within range"
-    )
+    description: str = "Ensure the XPath-selected value (attribute or text) is numeric and within range"
 
     def validate(self, xml: Any) -> ValidationResult:
         root = _as_root(xml)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,309 @@
+"""Tests for the MCP server tool functions.
+
+These tests call the underlying tool functions directly (without the MCP
+protocol layer) to verify the QA pipeline logic exposed to AI agents.
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+
+import pytest
+
+from healthcare_ai_guardrails.mcp_server import (
+    describe_spec,
+    list_validator_types,
+    run_guardrails,
+    validate_spec,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+SIMPLE_RANGE_SPEC = textwrap.dedent(
+    """
+    input:
+      - type: range
+        name: probability_range
+        path: ["probability"]
+        min: 0.0
+        max: 1.0
+    """
+)
+
+REQUIRED_FIELDS_SPEC = textwrap.dedent(
+    """
+    input:
+      - type: required_fields
+        name: required_check
+        paths: [["patient_id"], ["study_date"]]
+    output:
+      - type: range
+        name: confidence_range
+        path: ["confidence"]
+        min: 0.0
+        max: 1.0
+    """
+)
+
+HL7_SPEC = textwrap.dedent(
+    """
+    input:
+      - type: hl7v2_field_exists
+        name: patient_id_present
+        path: PID-3
+      - type: hl7v2_value_in_list
+        name: patient_sex_valid
+        path: PID-8
+        allowed: [M, F, O, U]
+    """
+)
+
+HL7_MESSAGE = (
+    "MSH|^~\\&|SendApp|SendFac|RecvApp|RecvFac|20240101120000||ADT^A01|MSG001|P|2.5\r"
+    "PID|1||12345^^^MRN||Doe^John||19800101|M|||123 Main St^^City^ST^12345\r"
+)
+
+INVALID_SPEC = textwrap.dedent(
+    """
+    input:
+      - type: totally_unknown_validator_type
+        name: bad_check
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# run_guardrails tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunGuardrails:
+    def test_inline_spec_and_data_pass(self):
+        result = run_guardrails(
+            spec_yaml=SIMPLE_RANGE_SPEC,
+            data_content='{"probability": 0.7}',
+            mode="input",
+        )
+        assert result["summary"]["all_passed"] is True
+        assert result["summary"]["total"] == 1
+        assert result["summary"]["passed"] == 1
+        assert result["results"][0]["name"] == "probability_range"
+        assert result["results"][0]["passed"] is True
+
+    def test_inline_spec_and_data_fail(self):
+        result = run_guardrails(
+            spec_yaml=SIMPLE_RANGE_SPEC,
+            data_content='{"probability": 1.5}',
+            mode="input",
+        )
+        assert result["summary"]["all_passed"] is False
+        assert result["summary"]["failed"] == 1
+        assert result["results"][0]["passed"] is False
+
+    def test_output_mode_uses_output_validators(self):
+        result = run_guardrails(
+            spec_yaml=REQUIRED_FIELDS_SPEC,
+            data_content='{"confidence": 0.9}',
+            mode="output",
+        )
+        assert result["summary"]["total"] == 1
+        assert result["results"][0]["name"] == "confidence_range"
+        assert result["results"][0]["passed"] is True
+
+    def test_input_mode_uses_input_validators(self):
+        result = run_guardrails(
+            spec_yaml=REQUIRED_FIELDS_SPEC,
+            data_content='{"patient_id": "P001", "study_date": "20240101"}',
+            mode="input",
+        )
+        assert result["summary"]["total"] == 1
+        assert result["results"][0]["name"] == "required_check"
+        assert result["results"][0]["passed"] is True
+
+    def test_hl7_inline_content(self):
+        result = run_guardrails(
+            spec_yaml=HL7_SPEC,
+            data_content=HL7_MESSAGE,
+            mode="input",
+        )
+        assert result["summary"]["total"] == 2
+        assert result["summary"]["passed"] == 2
+
+    def test_spec_from_file(self, tmp_path):
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(SIMPLE_RANGE_SPEC)
+        result = run_guardrails(
+            spec_path=str(spec_file),
+            data_content='{"probability": 0.5}',
+            mode="input",
+        )
+        assert result["summary"]["all_passed"] is True
+
+    def test_data_from_file(self, tmp_path):
+        data_file = tmp_path / "data.json"
+        data_file.write_text('{"probability": 0.3}')
+        result = run_guardrails(
+            spec_yaml=SIMPLE_RANGE_SPEC,
+            data_path=str(data_file),
+            mode="input",
+        )
+        assert result["summary"]["all_passed"] is True
+
+    def test_missing_data_returns_error(self):
+        result = run_guardrails(spec_yaml=SIMPLE_RANGE_SPEC, mode="input")
+        assert "error" in result
+
+    def test_bad_spec_returns_error(self):
+        result = run_guardrails(
+            spec_yaml=INVALID_SPEC,
+            data_content='{"x": 1}',
+            mode="input",
+        )
+        assert "error" in result
+
+    def test_result_has_severity_field(self):
+        result = run_guardrails(
+            spec_yaml=SIMPLE_RANGE_SPEC,
+            data_content='{"probability": 0.5}',
+            mode="input",
+        )
+        r = result["results"][0]
+        assert "severity" in r
+        assert isinstance(r["severity"], str)
+
+    def test_result_has_context_field(self):
+        result = run_guardrails(
+            spec_yaml=SIMPLE_RANGE_SPEC,
+            data_content='{"probability": 0.5}',
+            mode="input",
+        )
+        assert "context" in result["results"][0]
+
+
+# ---------------------------------------------------------------------------
+# list_validator_types tests
+# ---------------------------------------------------------------------------
+
+
+class TestListValidatorTypes:
+    def test_returns_validators_list(self):
+        result = list_validator_types()
+        assert "validators" in result
+        assert isinstance(result["validators"], list)
+        assert len(result["validators"]) > 0
+
+    def test_returns_categories(self):
+        result = list_validator_types()
+        assert "categories" in result
+        cats = result["categories"]
+        assert "generic" in cats
+        assert "dicom" in cats
+        assert "hl7v2" in cats
+        assert "hl7v3" in cats
+
+    def test_all_validators_have_required_keys(self):
+        result = list_validator_types()
+        for v in result["validators"]:
+            assert "type" in v
+            assert "description" in v
+            assert "required_params" in v
+            assert "optional_params" in v
+            assert "category" in v
+
+    def test_known_types_are_present(self):
+        result = list_validator_types()
+        types = {v["type"] for v in result["validators"]}
+        assert "range" in types
+        assert "dicom_modality" in types
+        assert "hl7v2_field_exists" in types
+        assert "hl7v3_xpath_exists" in types
+        assert "json_schema" in types
+
+    def test_total_matches_list_length(self):
+        result = list_validator_types()
+        assert result["total"] == len(result["validators"])
+
+
+# ---------------------------------------------------------------------------
+# validate_spec tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSpec:
+    def test_valid_spec_inline(self):
+        result = validate_spec(spec_yaml=SIMPLE_RANGE_SPEC)
+        assert result["valid"] is True
+        assert result["errors"] == []
+        assert result["input_count"] == 1
+        assert result["output_count"] == 0
+
+    def test_valid_spec_with_both_sections(self):
+        result = validate_spec(spec_yaml=REQUIRED_FIELDS_SPEC)
+        assert result["valid"] is True
+        assert result["input_count"] == 1
+        assert result["output_count"] == 1
+
+    def test_invalid_validator_type(self):
+        result = validate_spec(spec_yaml=INVALID_SPEC)
+        assert result["valid"] is False
+        assert len(result["errors"]) > 0
+        assert result["input_count"] == 0
+
+    def test_invalid_yaml_syntax(self):
+        bad_yaml = "input:\n  - type: range\n    name: [unclosed"
+        result = validate_spec(spec_yaml=bad_yaml)
+        assert result["valid"] is False
+        assert len(result["errors"]) > 0
+
+    def test_valid_spec_from_file(self, tmp_path):
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text(SIMPLE_RANGE_SPEC)
+        result = validate_spec(spec_path=str(spec_file))
+        assert result["valid"] is True
+
+    def test_empty_spec_is_valid(self):
+        result = validate_spec(spec_yaml="input: []\noutput: []")
+        assert result["valid"] is True
+        assert result["input_count"] == 0
+        assert result["output_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# describe_spec tests
+# ---------------------------------------------------------------------------
+
+
+class TestDescribeSpec:
+    def test_returns_input_and_output_sections(self):
+        result = describe_spec(spec_yaml=REQUIRED_FIELDS_SPEC)
+        assert "input_validators" in result
+        assert "output_validators" in result
+
+    def test_input_validator_has_required_fields(self):
+        result = describe_spec(spec_yaml=SIMPLE_RANGE_SPEC)
+        v = result["input_validators"][0]
+        assert "name" in v
+        assert "description" in v
+        assert "severity" in v
+        assert "validator_class" in v
+
+    def test_counts_match(self):
+        result = describe_spec(spec_yaml=REQUIRED_FIELDS_SPEC)
+        assert result["input_count"] == 1
+        assert result["output_count"] == 1
+        assert len(result["input_validators"]) == 1
+        assert len(result["output_validators"]) == 1
+
+    def test_validator_name_is_correct(self):
+        result = describe_spec(spec_yaml=SIMPLE_RANGE_SPEC)
+        assert result["input_validators"][0]["name"] == "probability_range"
+
+    def test_validator_class_is_set(self):
+        result = describe_spec(spec_yaml=SIMPLE_RANGE_SPEC)
+        assert result["input_validators"][0]["validator_class"] == "RangeCheck"
+
+    def test_error_on_bad_spec(self):
+        result = describe_spec(spec_yaml=INVALID_SPEC)
+        assert "error" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,10 +5,7 @@ protocol layer) to verify the QA pipeline logic exposed to AI agents.
 """
 from __future__ import annotations
 
-import json
 import textwrap
-
-import pytest
 
 from healthcare_ai_guardrails.mcp_server import (
     describe_spec,
@@ -150,6 +147,15 @@ class TestRunGuardrails:
             mode="input",
         )
         assert result["summary"]["all_passed"] is True
+
+    def test_invalid_mode_returns_error(self):
+        result = run_guardrails(
+            spec_yaml=SIMPLE_RANGE_SPEC,
+            data_content='{"probability": 0.5}',
+            mode="batch",
+        )
+        assert "error" in result
+        assert "mode" in result["error"].lower()
 
     def test_missing_data_returns_error(self):
         result = run_guardrails(spec_yaml=SIMPLE_RANGE_SPEC, mode="input")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3,6 +3,7 @@
 These tests call the underlying tool functions directly (without the MCP
 protocol layer) to verify the QA pipeline logic exposed to AI agents.
 """
+
 from __future__ import annotations
 
 import textwrap
@@ -18,19 +19,16 @@ from healthcare_ai_guardrails.mcp_server import (
 # Shared fixtures / helpers
 # ---------------------------------------------------------------------------
 
-SIMPLE_RANGE_SPEC = textwrap.dedent(
-    """
+SIMPLE_RANGE_SPEC = textwrap.dedent("""
     input:
       - type: range
         name: probability_range
         path: ["probability"]
         min: 0.0
         max: 1.0
-    """
-)
+    """)
 
-REQUIRED_FIELDS_SPEC = textwrap.dedent(
-    """
+REQUIRED_FIELDS_SPEC = textwrap.dedent("""
     input:
       - type: required_fields
         name: required_check
@@ -41,11 +39,9 @@ REQUIRED_FIELDS_SPEC = textwrap.dedent(
         path: ["confidence"]
         min: 0.0
         max: 1.0
-    """
-)
+    """)
 
-HL7_SPEC = textwrap.dedent(
-    """
+HL7_SPEC = textwrap.dedent("""
     input:
       - type: hl7v2_field_exists
         name: patient_id_present
@@ -54,21 +50,18 @@ HL7_SPEC = textwrap.dedent(
         name: patient_sex_valid
         path: PID-8
         allowed: [M, F, O, U]
-    """
-)
+    """)
 
 HL7_MESSAGE = (
     "MSH|^~\\&|SendApp|SendFac|RecvApp|RecvFac|20240101120000||ADT^A01|MSG001|P|2.5\r"
     "PID|1||12345^^^MRN||Doe^John||19800101|M|||123 Main St^^City^ST^12345\r"
 )
 
-INVALID_SPEC = textwrap.dedent(
-    """
+INVALID_SPEC = textwrap.dedent("""
     input:
       - type: totally_unknown_validator_type
         name: bad_check
-    """
-)
+    """)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a stdio MCP server (hc-guardrails-mcp) so AI agents can run the
healthcare guardrails validation pipeline automatically. Exposes four tools:
- run_guardrails: run validators from a spec against data (file or inline)
- list_validator_types: catalog all available validator types + parameters
- validate_spec: parse and validate a YAML spec before running it
- describe_spec: describe what each validator in a spec checks

Also refactors shared data-loading helpers into _io.py (used by both the
CLI and MCP server) and adds load_spec_from_string() to config.py for
inline YAML spec support.
