### PR TITLE
feat: add RT-AI-Model-Card integration for automatic guardrail spec generation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR}"
+
+echo "==> Installing package with dev dependencies..."
+pip install -e ".[dev]" --quiet
+
+echo "==> Installing pre-commit hooks..."
+pre-commit install
+
+echo "==> Session start complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.5.0 - 2026-03-14
+
+### Added
+- **RT-AI-Model-Card integration**: `load_model_card`, `model_card_to_yaml`, `model_card_to_spec`, and `model_card_to_extraction_summary` parse an exported model card JSON and auto-generate a guardrail YAML spec covering modality, patient age, sex, patient position, slice thickness, and kVp.
+- `--from-model-card` and `--generate-spec` CLI flags for model-card-driven validation workflows (no manual YAML authoring required).
+- `generate_spec_from_model_card` MCP tool for AI-agent workflows.
+- Sample model card JSON at `examples/model_card.sample.json`.
+
 ## v0.4.0 - 2026-02-25
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ from healthcare_ai_guardrails import model_card_to_extraction_summary
 
 summary = model_card_to_extraction_summary(card)
 print(summary["extracted"])       # {"modalities": ["CT"], "age_range": [18, 75], ...}
-print(summary["skipped_fields"])  # ["bmi", "fov", ...]
+print(summary["skipped_fields"])  # e.g. ["age", "sex"] for fields present but unparseable
 ```
 
 A sample model card JSON is provided at `examples/model_card.sample.json`.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ If your AI model was documented with the [RT-AI-Model-Card](https://github.com/M
 
 ### What gets extracted
 
+**Input validators** (applied to the data fed into the model):
+
 | Model Card field | Guardrail validator | Severity |
 |---|---|---|
 | `technical_specifications.model_inputs` | `dicom_modality` | error |
@@ -158,8 +160,17 @@ If your AI model was documented with the [RT-AI-Model-Card](https://github.com/M
 | per-modality `patient_positioning` | `dicom_patient_position` | warning |
 | per-modality `scan_acquisition_parameters` → slice thickness | `dicom_slice_thickness` | warning |
 | per-modality `scan_acquisition_parameters` → kVp | `dicom_kvp` | warning |
+| per-modality `scanner_model` | `dicom_generic_value_in_list` on `ManufacturerModelName` | warning |
 
-Fields not in the table (e.g. `bmi`, `mAs`, `fov`, `image_resolution`) are silently skipped — no validator is emitted for them.
+**Output validators** (applied to what the model produces):
+
+| Model Card field | Guardrail validator | Severity |
+|---|---|---|
+| `technical_specifications.model_outputs` | `dicom_modality` | error |
+
+> **Note on scanner model values:** DICOM `ManufacturerModelName` tags often omit the manufacturer prefix (e.g. `"SOMATOM Definition AS+"` rather than `"Siemens SOMATOM Definition AS+"`). Review and adjust the generated `allowed_values` before use in production.
+
+Fields not listed above (e.g. `bmi`, `mAs`, `fov`, `image_resolution`) cannot be mapped to existing validators and are silently skipped. They are listed in a comment block at the top of the generated YAML and printed as warnings to stderr by the CLI, so you know what to add manually.
 
 ### CLI usage
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,64 @@ hc-guardrails examples/tutorials/autocontouring_tutorial.yaml path/to/ct.dcm --m
 hc-guardrails examples/tutorials/autocontouring_tutorial.yaml path/to/rs.dcm --mode output
 ```
 
+## Model Card Integration (RT-AI-Model-Card)
+
+If your AI model was documented with the [RT-AI-Model-Card](https://github.com/MIRO-UCLouvain/RT-AI-Model-Card) Streamlit tool, you can convert the exported JSON directly into a guardrail spec — no manual YAML authoring required.
+
+### What gets extracted
+
+| Model Card field | Guardrail validator | Severity |
+|---|---|---|
+| `technical_specifications.model_inputs` | `dicom_modality` | error |
+| `training_data.age` | `dicom_patient_age` | warning |
+| `training_data.sex` | `dicom_patient_sex` | warning |
+| per-modality `patient_positioning` | `dicom_patient_position` | warning |
+| per-modality `scan_acquisition_parameters` → slice thickness | `dicom_slice_thickness` | warning |
+| per-modality `scan_acquisition_parameters` → kVp | `dicom_kvp` | warning |
+
+Fields not in the table (e.g. `bmi`, `mAs`, `fov`, `image_resolution`) are silently skipped — no validator is emitted for them.
+
+### CLI usage
+
+```bash
+# Generate a reusable YAML spec from a model card and save it
+hc-guardrails --from-model-card model_card.json --generate-spec output.yaml
+
+# Print the generated spec to stdout (for inspection / piping)
+hc-guardrails --from-model-card model_card.json --generate-spec
+
+# Run guardrails directly without a separate spec file
+hc-guardrails --from-model-card model_card.json patient.dcm --mode input
+```
+
+### Python API
+
+```python
+from healthcare_ai_guardrails import load_model_card, model_card_to_yaml, model_card_to_spec
+
+card = load_model_card("model_card.json")
+
+# Inspect the generated YAML
+print(model_card_to_yaml(card))
+
+# Or get a ready-to-use Spec object and run it yourself
+spec = model_card_to_spec(card)
+```
+
+To debug what was (and wasn't) extracted:
+
+```python
+from healthcare_ai_guardrails import model_card_to_extraction_summary
+
+summary = model_card_to_extraction_summary(card)
+print(summary["extracted"])       # {"modalities": ["CT"], "age_range": [18, 75], ...}
+print(summary["skipped_fields"])  # ["bmi", "fov", ...]
+```
+
+A sample model card JSON is provided at `examples/model_card.sample.json`.
+
+---
+
 ## MCP server (AI agent integration)
 
 The package ships a [Model Context Protocol](https://modelcontextprotocol.io) server so AI agents (Claude Desktop, Claude Code, any MCP-compatible client) can run the guardrails QA pipeline automatically.
@@ -182,6 +240,7 @@ claude mcp add healthcare-guardrails hc-guardrails-mcp
 | `list_validator_types` | Return the full catalog of available validator types, grouped by category, with their parameters. Useful for building new specs. |
 | `validate_spec` | Parse a YAML spec and report any configuration errors (unknown types, YAML syntax problems) before running it on real data. |
 | `describe_spec` | Load a spec and return a human-readable description of what each validator checks (name, description, severity). |
+| `generate_spec_from_model_card` | Convert an RT-AI-Model-Card JSON string into a guardrail YAML spec. Returns the YAML, a summary of extracted parameters, and a list of skipped fields. |
 
 ### Example: run guardrails from a spec file
 

--- a/examples/model_card.sample.json
+++ b/examples/model_card.sample.json
@@ -1,0 +1,59 @@
+{
+  "task": "Segmentation",
+  "card_metadata": {
+    "card_creation_date": "2026-01-15",
+    "version_number": "1.0.0",
+    "version_changes": "Initial release"
+  },
+  "model_basic_information": {
+    "name": "HeadNeck-AutoSeg-v1",
+    "creation_date": "2026-01-10",
+    "version_number": "1.0.0",
+    "model_scope_summary": "Automatic segmentation of head and neck organs at risk for radiotherapy treatment planning.",
+    "model_scope_anatomical_site": "Head and Neck",
+    "intended_users": "Radiation oncologists and medical physicists",
+    "type_of_learning_architecture": "3D U-Net",
+    "developed_by_name": "Example RT Lab",
+    "developed_by_institution": "Example University Hospital"
+  },
+  "technical_specifications": {
+    "model_pipeline_summary": "CT-based 3D segmentation pipeline with pre-processing normalisation and post-processing morphological refinement.",
+    "model_inputs": ["CT"],
+    "model_outputs": ["RTSTRUCT"],
+    "pre_processing": "HU windowing [-200, 400], isotropic resampling to 1mm",
+    "post_processing": "Connected component analysis, morphological closing"
+  },
+  "training_data": {
+    "total_size": "500 CT scans",
+    "number_of_patients": "500",
+    "source": "Multi-centre retrospective data from 3 European hospitals",
+    "acquisition_period": "2018–2023",
+    "inclusion_exclusion_criteria": "Adults with head and neck cancer, primary diagnosis, no prior RT",
+    "age": "25-75 years",
+    "sex": "Male and Female",
+    "bmi": "18-35 kg/m2",
+    "icd10_11": "C00-C14 (malignant neoplasms of lip, oral cavity and pharynx)",
+    "inputs_outputs_technical_specifications": [
+      {
+        "entry": "CT",
+        "source": "model_inputs",
+        "image_resolution": "512x512, 1mm isotropic after resampling",
+        "patient_positioning": "HFS",
+        "scanner_model": "Siemens SOMATOM Definition AS+, GE Discovery CT750 HD",
+        "scan_acquisition_parameters": "kVp: 120, mAs: 200-300, slice thickness: 1-3mm",
+        "scan_reconstruction_parameters": "Standard kernel, NA if Not Applicable",
+        "fov": "300-500mm"
+      }
+    ],
+    "validation_strategy": "5-fold cross-validation",
+    "validation_data_partition": "80/20 train/validation split per fold",
+    "epochs": "300",
+    "optimiser": "Adam",
+    "learning_rate": "1e-4",
+    "model_choice_criteria": "Best Dice score on validation set"
+  },
+  "other_considerations": {
+    "responsible_use_and_ethical_considerations": "Model is intended as a decision-support tool. Clinical review of all segmentations is mandatory before use in treatment planning.",
+    "risk_analysis": "Potential for missed or under-segmented structures in atypical anatomy."
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "healthcare-ai-guardrails"
-version = "0.4.0"
+version = "0.5.0"
 description = "Guardrails for AI input/output validation in healthcare, with DICOM support"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/healthcare_ai_guardrails/__init__.py
+++ b/src/healthcare_ai_guardrails/__init__.py
@@ -41,6 +41,7 @@ from .validators.hl7v3 import (
     HL7v3XPathNumericRangeCheck,
 )
 from .config import load_spec, load_spec_from_string
+from .model_card import load_model_card, model_card_to_spec, model_card_to_yaml
 
 __all__ = [
     "__version__",
@@ -72,4 +73,7 @@ __all__ = [
     "HL7v3XPathNumericRangeCheck",
     "load_spec",
     "load_spec_from_string",
+    "load_model_card",
+    "model_card_to_spec",
+    "model_card_to_yaml",
 ]

--- a/src/healthcare_ai_guardrails/__init__.py
+++ b/src/healthcare_ai_guardrails/__init__.py
@@ -41,7 +41,12 @@ from .validators.hl7v3 import (
     HL7v3XPathNumericRangeCheck,
 )
 from .config import load_spec, load_spec_from_string
-from .model_card import load_model_card, model_card_to_spec, model_card_to_yaml
+from .model_card import (
+    load_model_card,
+    model_card_to_extraction_summary,
+    model_card_to_spec,
+    model_card_to_yaml,
+)
 
 __all__ = [
     "__version__",
@@ -74,6 +79,7 @@ __all__ = [
     "load_spec",
     "load_spec_from_string",
     "load_model_card",
+    "model_card_to_extraction_summary",
     "model_card_to_spec",
     "model_card_to_yaml",
 ]

--- a/src/healthcare_ai_guardrails/cli.py
+++ b/src/healthcare_ai_guardrails/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from ._io import load_data_from_path
@@ -9,15 +10,130 @@ from .runner import GuardrailRunner
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Healthcare AI Guardrails")
-    parser.add_argument("spec", type=str, help="Path to YAML spec file")
-    parser.add_argument(
-        "data", type=str, help="Path to input/output data (DICOM .dcm or JSON)"
+    parser = argparse.ArgumentParser(
+        description="Healthcare AI Guardrails",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Validate using an existing spec file:
+  hc-guardrails spec.yaml data.dcm --mode input
+
+  # Generate a spec from an RT-AI-Model-Card JSON and print to stdout:
+  hc-guardrails --from-model-card model_card.json --generate-spec
+
+  # Generate a spec and save to file:
+  hc-guardrails --from-model-card model_card.json --generate-spec output.yaml
+
+  # Validate data using a model card instead of a spec file:
+  hc-guardrails --from-model-card model_card.json data.dcm --mode input
+""",
     )
     parser.add_argument(
-        "--mode", choices=["input", "output"], default="input", help="Which set to run"
+        "spec",
+        type=str,
+        nargs="?",
+        help="Path to YAML spec file (not required when --from-model-card is used)",
+    )
+    parser.add_argument(
+        "data",
+        type=str,
+        nargs="?",
+        help="Path to input/output data (DICOM .dcm or JSON)",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["input", "output"],
+        default="input",
+        help="Which set of validators to run (default: input)",
+    )
+    parser.add_argument(
+        "--from-model-card",
+        type=str,
+        metavar="MODEL_CARD_JSON",
+        help="Path to an RT-AI-Model-Card JSON export; generates guardrail spec automatically",
+    )
+    parser.add_argument(
+        "--generate-spec",
+        type=str,
+        metavar="OUTPUT_YAML",
+        nargs="?",
+        const="-",
+        help=(
+            "Generate a guardrail YAML spec from --from-model-card and write it to "
+            "OUTPUT_YAML (use '-' or omit for stdout). Exits without running validation."
+        ),
     )
     args = parser.parse_args(argv)
+
+    # ------------------------------------------------------------------
+    # Mode 1: --from-model-card + --generate-spec  →  write spec and exit
+    # ------------------------------------------------------------------
+    if args.from_model_card and args.generate_spec is not None:
+        from .model_card import load_model_card, model_card_to_yaml
+
+        card = load_model_card(args.from_model_card)
+        yaml_str = model_card_to_yaml(card)
+
+        if args.generate_spec == "-":
+            sys.stdout.write(yaml_str)
+        else:
+            Path(args.generate_spec).write_text(yaml_str, encoding="utf-8")
+            print(f"Spec written to {args.generate_spec}")
+        return 0
+
+    # ------------------------------------------------------------------
+    # Mode 2: --from-model-card + data  →  validate using generated spec
+    # ------------------------------------------------------------------
+    if args.from_model_card:
+        if not args.data:
+            # Accept data as the first positional even when --from-model-card is used
+            if args.spec:
+                # The user put data in the spec slot (positional)
+                data_path_str = args.spec
+            else:
+                parser.error(
+                    "--from-model-card requires either a data path argument "
+                    "or --generate-spec"
+                )
+                return 1
+        else:
+            data_path_str = args.data
+
+        from .model_card import load_model_card, model_card_to_spec
+
+        card = load_model_card(args.from_model_card)
+        spec = model_card_to_spec(card)
+
+        try:
+            data = load_data_from_path(Path(data_path_str))
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+
+        validators = (
+            spec.input_validators if args.mode == "input" else spec.output_validators
+        )
+        runner = GuardrailRunner(validators)
+        results = runner.run(data)
+
+        any_fail = False
+        for r in results:
+            status = "PASS" if r.passed else "FAIL"
+            if not r.passed:
+                any_fail = True
+            msg = f" - {r.message}" if r.message else ""
+            print(f"[{status}] ({r.severity}) {r.name}{msg}")
+
+        return 1 if any_fail else 0
+
+    # ------------------------------------------------------------------
+    # Mode 3: spec + data  →  existing behaviour
+    # ------------------------------------------------------------------
+    if not args.spec or not args.data:
+        parser.error(
+            "Provide either (1) spec and data positional arguments, or "
+            "(2) --from-model-card with a data path or --generate-spec"
+        )
+        return 1
 
     spec = load_spec(args.spec)
     try:

--- a/src/healthcare_ai_guardrails/cli.py
+++ b/src/healthcare_ai_guardrails/cli.py
@@ -69,9 +69,24 @@ Examples:
     # Mode 1: --from-model-card + --generate-spec  →  write spec and exit
     # ------------------------------------------------------------------
     if args.from_model_card and args.generate_spec is not None:
-        from .model_card import load_model_card, model_card_to_yaml
+        from .model_card import (
+            load_model_card,
+            model_card_to_extraction_summary,
+            model_card_to_yaml,
+        )
 
         card = load_model_card(args.from_model_card)
+        summary = model_card_to_extraction_summary(card)
+        if summary["skipped_fields"]:
+            print(
+                f"Warning: the following fields could not be extracted and were skipped: "
+                f"{', '.join(summary['skipped_fields'])}",
+                file=sys.stderr,
+            )
+            print(
+                "Review the generated spec and add validators for these fields manually.",
+                file=sys.stderr,
+            )
         yaml_str = model_card_to_yaml(card)
 
         if args.generate_spec == "-":
@@ -99,9 +114,20 @@ Examples:
         else:
             data_path_str = args.data
 
-        from .model_card import load_model_card, model_card_to_spec
+        from .model_card import (
+            load_model_card,
+            model_card_to_extraction_summary,
+            model_card_to_spec,
+        )
 
         card = load_model_card(args.from_model_card)
+        summary = model_card_to_extraction_summary(card)
+        if summary["skipped_fields"]:
+            print(
+                f"Warning: the following fields could not be extracted and were skipped: "
+                f"{', '.join(summary['skipped_fields'])}",
+                file=sys.stderr,
+            )
         spec = model_card_to_spec(card)
 
         try:

--- a/src/healthcare_ai_guardrails/mcp_server.py
+++ b/src/healthcare_ai_guardrails/mcp_server.py
@@ -542,6 +542,66 @@ def describe_spec(
     }
 
 
+@mcp.tool()
+def generate_spec_from_model_card(
+    model_card_json: str,
+) -> Dict[str, Any]:
+    """Generate a guardrail YAML spec from an RT-AI-Model-Card JSON export.
+
+    Parses an exported JSON from the RT-AI-Model-Card tool
+    (https://github.com/MIRO-UCLouvain/RT-AI-Model-Card) and returns a
+    guardrail YAML spec enforcing the training distribution at inference time.
+
+    The following fields are extracted when present and parseable:
+    - Modality (from technical_specifications.model_inputs) → dicom_modality
+    - Age range (from training_data.age) → dicom_patient_age
+    - Sex (from training_data.sex) → dicom_patient_sex
+    - Patient positioning → dicom_patient_position
+    - Slice thickness → dicom_slice_thickness
+    - kVp → dicom_kvp
+
+    Fields that cannot be reliably parsed from free text are skipped and
+    listed in "skipped_fields".
+
+    Args:
+        model_card_json: The full JSON content of an RT-AI-Model-Card export
+            as a string.
+
+    Returns:
+        Dict with:
+        - "yaml": the generated guardrail YAML spec string
+        - "extracted": summary of successfully extracted parameters
+        - "skipped_fields": list of fields that could not be parsed
+        - "error": present only on failure
+    """
+    import json as _json
+
+    from .model_card import (
+        model_card_to_extraction_summary,
+        model_card_to_yaml,
+    )
+
+    try:
+        card = _json.loads(model_card_json)
+    except _json.JSONDecodeError as exc:
+        return {"error": f"Invalid JSON: {exc}"}
+
+    if not isinstance(card, dict):
+        return {"error": "model_card_json must be a JSON object"}
+
+    try:
+        yaml_str = model_card_to_yaml(card)
+        summary = model_card_to_extraction_summary(card)
+    except Exception as exc:
+        return {"error": f"Failed to generate spec: {exc}"}
+
+    return {
+        "yaml": yaml_str,
+        "extracted": summary["extracted"],
+        "skipped_fields": summary["skipped_fields"],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------

--- a/src/healthcare_ai_guardrails/model_card.py
+++ b/src/healthcare_ai_guardrails/model_card.py
@@ -161,14 +161,10 @@ def _parse_sex(text: str) -> List[str]:
     return result
 
 
-def _parse_modalities(model_card: Dict[str, Any]) -> List[str]:
-    """Extract and normalise modality codes from technical_specifications.model_inputs."""
-    tech = model_card.get("technical_specifications", {})
-    raw: Any = tech.get("model_inputs", [])
-
+def _normalise_modality_list(raw: Any) -> List[str]:
+    """Normalise a raw list of modality strings to DICOM codes."""
     if not isinstance(raw, list):
         return []
-
     normalised: List[str] = []
     for item in raw:
         if not isinstance(item, str):
@@ -177,8 +173,19 @@ def _parse_modalities(model_card: Dict[str, Any]) -> List[str]:
         code = _MODALITY_ALIASES.get(code, code)
         if code and code not in normalised:
             normalised.append(code)
-
     return normalised
+
+
+def _parse_modalities(model_card: Dict[str, Any]) -> List[str]:
+    """Extract and normalise modality codes from technical_specifications.model_inputs."""
+    tech = model_card.get("technical_specifications", {})
+    return _normalise_modality_list(tech.get("model_inputs", []))
+
+
+def _parse_output_modalities(model_card: Dict[str, Any]) -> List[str]:
+    """Extract and normalise modality codes from technical_specifications.model_outputs."""
+    tech = model_card.get("technical_specifications", {})
+    return _normalise_modality_list(tech.get("model_outputs", []))
 
 
 def _parse_patient_positions(text: str) -> List[str]:
@@ -294,6 +301,27 @@ def _parse_kvp(text: str) -> Tuple[Optional[float], Optional[float]]:
     return None, None
 
 
+def _parse_scanner_models(text: str) -> List[str]:
+    """Extract individual scanner model names from a comma-separated free-text string.
+
+    The RT-AI-Model-Card ``scanner_model`` field typically contains one or more
+    make/model strings separated by commas, e.g.::
+
+        "Siemens SOMATOM Definition AS+, GE Discovery CT750 HD"
+
+    Each value is returned trimmed.  The caller should use these as the
+    ``allowed_values`` for a ``dicom_generic_value_in_list`` validator on the
+    ``ManufacturerModelName`` DICOM tag — note that DICOM tag values may not
+    include the manufacturer prefix, so review the generated validator before
+    use.
+
+    Returns an empty list if the text is blank.
+    """
+    if not text or not text.strip():
+        return []
+    return [s.strip() for s in text.split(",") if s.strip()]
+
+
 # ---------------------------------------------------------------------------
 # Spec/YAML generation
 # ---------------------------------------------------------------------------
@@ -301,12 +329,13 @@ def _parse_kvp(text: str) -> Tuple[Optional[float], Optional[float]]:
 
 def _build_spec_entries(
     model_card: Dict[str, Any],
-) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
-    """Build a list of validator dicts and an extraction summary from a model card.
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, Any]]:
+    """Build input and output validator dicts plus an extraction summary.
 
-    Returns (entries, extracted_summary).
+    Returns ``(input_entries, output_entries, extracted_summary)``.
     """
-    entries: List[Dict[str, Any]] = []
+    input_entries: List[Dict[str, Any]] = []
+    output_entries: List[Dict[str, Any]] = []
     extracted: Dict[str, Any] = {}
     skipped: List[str] = []
 
@@ -317,10 +346,10 @@ def _build_spec_entries(
         or "unknown"
     )
 
-    # --- Modality ---
+    # --- Input modality ---
     modalities = _parse_modalities(model_card)
     if modalities:
-        entries.append(
+        input_entries.append(
             {
                 "type": "dicom_modality",
                 "name": "allowed_modality",
@@ -347,7 +376,7 @@ def _build_spec_entries(
             entry["min_years"] = min_age
         if max_age is not None:
             entry["max_years"] = max_age
-        entries.append(entry)
+        input_entries.append(entry)
         extracted["age_range"] = [min_age, max_age]
     else:
         skipped.append("age")
@@ -356,7 +385,7 @@ def _build_spec_entries(
     sex_text = str(training.get("sex", "") or "")
     sex_codes = _parse_sex(sex_text)
     if sex_codes:
-        entries.append(
+        input_entries.append(
             {
                 "type": "dicom_patient_sex",
                 "name": "allowed_patient_sex",
@@ -369,12 +398,13 @@ def _build_spec_entries(
     else:
         skipped.append("sex")
 
-    # --- Per-modality scan parameters ---
+    # --- Per-modality scan parameters (inputs only) ---
     io_specs: Any = training.get("inputs_outputs_technical_specifications", [])
     if isinstance(io_specs, list):
         all_positions: List[str] = []
         all_slice_thicknesses: List[Tuple[Optional[float], Optional[float]]] = []
         all_kvps: List[Tuple[Optional[float], Optional[float]]] = []
+        all_scanner_models: List[str] = []
 
         for spec_item in io_specs:
             if not isinstance(spec_item, dict):
@@ -397,8 +427,13 @@ def _build_spec_entries(
             if kvp_range != (None, None):
                 all_kvps.append(kvp_range)
 
+            scanner_text = str(spec_item.get("scanner_model", "") or "")
+            for model in _parse_scanner_models(scanner_text):
+                if model not in all_scanner_models:
+                    all_scanner_models.append(model)
+
         if all_positions:
-            entries.append(
+            input_entries.append(
                 {
                     "type": "dicom_patient_position",
                     "name": "allowed_patient_position",
@@ -425,7 +460,7 @@ def _build_spec_entries(
                 st_entry["min_mm"] = min(mins)
             if maxs:
                 st_entry["max_mm"] = max(maxs)
-            entries.append(st_entry)
+            input_entries.append(st_entry)
             extracted["slice_thickness_mm"] = [
                 st_entry.get("min_mm"),
                 st_entry.get("max_mm"),
@@ -446,24 +481,68 @@ def _build_spec_entries(
                 kvp_entry["min_kvp"] = min(mins_kvp)
             if maxs_kvp:
                 kvp_entry["max_kvp"] = max(maxs_kvp)
-            entries.append(kvp_entry)
+            input_entries.append(kvp_entry)
             extracted["kvp"] = [kvp_entry.get("min_kvp"), kvp_entry.get("max_kvp")]
         else:
             skipped.append("kvp")
 
+        if all_scanner_models:
+            input_entries.append(
+                {
+                    "type": "dicom_generic_value_in_list",
+                    "name": "allowed_scanner_model",
+                    "description": (
+                        "Scanner model must match training data. "
+                        "Review ManufacturerModelName values — DICOM tags may omit "
+                        "the manufacturer prefix (e.g. 'SOMATOM Definition AS+' not "
+                        "'Siemens SOMATOM Definition AS+')."
+                    ),
+                    "tag": "ManufacturerModelName",
+                    "allowed_values": all_scanner_models,
+                    "severity": "warning",
+                }
+            )
+            extracted["scanner_models"] = all_scanner_models
+        else:
+            skipped.append("scanner_model")
+
+    # --- Output modality ---
+    # Only emit if model_outputs is explicitly present in the card.
+    tech = model_card.get("technical_specifications", {})
+    if "model_outputs" in tech:
+        output_modalities = _parse_output_modalities(model_card)
+        if output_modalities:
+            output_entries.append(
+                {
+                    "type": "dicom_modality",
+                    "name": "allowed_output_modality",
+                    "description": (
+                        f"Output modality must match model specification for: {model_name}"
+                    ),
+                    "allowed": output_modalities,
+                    "severity": "error",
+                }
+            )
+            extracted["output_modalities"] = output_modalities
+        else:
+            skipped.append("output_modalities")
+
     extracted["skipped_fields"] = skipped
-    return entries, extracted
+    return input_entries, output_entries, extracted
 
 
 def model_card_to_yaml(model_card: Dict[str, Any]) -> str:
     """Convert an RT-AI-Model-Card dict into a guardrail YAML spec string.
 
-    Fields that cannot be reliably parsed from free text are silently skipped.
+    Fields that cannot be reliably parsed from free text are silently skipped;
+    they are listed in a comment block at the top of the generated YAML so the
+    user knows what to add manually.
 
     :param model_card: Parsed RT-AI-Model-Card JSON as a dict.
     :return: YAML string suitable for use with :func:`load_spec_from_string`.
     """
-    entries, _ = _build_spec_entries(model_card)
+    input_entries, output_entries, summary = _build_spec_entries(model_card)
+    skipped = summary.get("skipped_fields", [])
 
     model_name: str = (
         model_card.get("model_basic_information", {}).get("name", "") or "unknown"
@@ -472,10 +551,19 @@ def model_card_to_yaml(model_card: Dict[str, Any]) -> str:
     header_lines = [
         f"# Auto-generated from RT-AI-Model-Card: {model_name}",
         "# Edit as needed before use in production.",
-        "",
     ]
 
-    spec_dict: Dict[str, Any] = {"input": entries, "output": []}
+    if skipped:
+        header_lines.append(
+            f"# Fields not extracted (unparseable or absent): {', '.join(skipped)}"
+        )
+        header_lines.append(
+            "# Review these fields and add validators manually if needed."
+        )
+
+    header_lines.append("")
+
+    spec_dict: Dict[str, Any] = {"input": input_entries, "output": output_entries}
     yaml_body = yaml.dump(
         spec_dict, default_flow_style=False, allow_unicode=True, sort_keys=False
     )
@@ -520,6 +608,6 @@ def model_card_to_extraction_summary(model_card: Dict[str, Any]) -> Dict[str, An
     :param model_card: Parsed RT-AI-Model-Card JSON as a dict.
     :return: Dict with keys ``extracted`` and ``skipped_fields``.
     """
-    _, extracted = _build_spec_entries(model_card)
+    _, __, extracted = _build_spec_entries(model_card)
     skipped = extracted.pop("skipped_fields", [])
     return {"extracted": extracted, "skipped_fields": skipped}

--- a/src/healthcare_ai_guardrails/model_card.py
+++ b/src/healthcare_ai_guardrails/model_card.py
@@ -30,7 +30,19 @@ from .config import load_spec_from_string, Spec
 # ---------------------------------------------------------------------------
 
 # DICOM standard patient position codes
-_DICOM_POSITIONS = {"HFS", "HFP", "FFS", "FFP", "HFDR", "HFDL", "FFDR", "FFDL", "SITTING", "LLD", "RLD"}
+_DICOM_POSITIONS = {
+    "HFS",
+    "HFP",
+    "FFS",
+    "FFP",
+    "HFDR",
+    "HFDL",
+    "FFDR",
+    "FFDL",
+    "SITTING",
+    "LLD",
+    "RLD",
+}
 
 # Text-description → DICOM code mappings (lowercase keys)
 _POSITION_TEXT_MAP: Dict[str, str] = {
@@ -188,7 +200,9 @@ def _parse_patient_positions(text: str) -> List[str]:
             found.append(code)
 
     # Extract standard uppercase codes
-    for code in re.findall(r"\b(HFS|HFP|FFS|FFP|HFDR|HFDL|FFDR|FFDL|SITTING|LLD|RLD)\b", t, re.IGNORECASE):
+    for code in re.findall(
+        r"\b(HFS|HFP|FFS|FFP|HFDR|HFDL|FFDR|FFDL|SITTING|LLD|RLD)\b", t, re.IGNORECASE
+    ):
         upper = code.upper()
         if upper not in found:
             found.append(upper)
@@ -284,7 +298,10 @@ def _parse_kvp(text: str) -> Tuple[Optional[float], Optional[float]]:
 # Spec/YAML generation
 # ---------------------------------------------------------------------------
 
-def _build_spec_entries(model_card: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+
+def _build_spec_entries(
+    model_card: Dict[str, Any],
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     """Build a list of validator dicts and an extraction summary from a model card.
 
     Returns (entries, extracted_summary).
@@ -303,13 +320,15 @@ def _build_spec_entries(model_card: Dict[str, Any]) -> Tuple[List[Dict[str, Any]
     # --- Modality ---
     modalities = _parse_modalities(model_card)
     if modalities:
-        entries.append({
-            "type": "dicom_modality",
-            "name": "allowed_modality",
-            "description": f"Modality must match training data for model: {model_name}",
-            "allowed": modalities,
-            "severity": "error",
-        })
+        entries.append(
+            {
+                "type": "dicom_modality",
+                "name": "allowed_modality",
+                "description": f"Modality must match training data for model: {model_name}",
+                "allowed": modalities,
+                "severity": "error",
+            }
+        )
         extracted["modalities"] = modalities
     else:
         skipped.append("modalities")
@@ -337,13 +356,15 @@ def _build_spec_entries(model_card: Dict[str, Any]) -> Tuple[List[Dict[str, Any]
     sex_text = str(training.get("sex", "") or "")
     sex_codes = _parse_sex(sex_text)
     if sex_codes:
-        entries.append({
-            "type": "dicom_patient_sex",
-            "name": "allowed_patient_sex",
-            "description": f"Patient sex within training distribution ({sex_text.strip()})",
-            "allowed": sex_codes,
-            "severity": "warning",
-        })
+        entries.append(
+            {
+                "type": "dicom_patient_sex",
+                "name": "allowed_patient_sex",
+                "description": f"Patient sex within training distribution ({sex_text.strip()})",
+                "allowed": sex_codes,
+                "severity": "warning",
+            }
+        )
         extracted["sex"] = sex_codes
     else:
         skipped.append("sex")
@@ -377,13 +398,15 @@ def _build_spec_entries(model_card: Dict[str, Any]) -> Tuple[List[Dict[str, Any]
                 all_kvps.append(kvp_range)
 
         if all_positions:
-            entries.append({
-                "type": "dicom_patient_position",
-                "name": "allowed_patient_position",
-                "description": "Patient position must match training data",
-                "allowed": all_positions,
-                "severity": "warning",
-            })
+            entries.append(
+                {
+                    "type": "dicom_patient_position",
+                    "name": "allowed_patient_position",
+                    "description": "Patient position must match training data",
+                    "allowed": all_positions,
+                    "severity": "warning",
+                }
+            )
             extracted["patient_positions"] = all_positions
         else:
             skipped.append("patient_positioning")
@@ -403,7 +426,10 @@ def _build_spec_entries(model_card: Dict[str, Any]) -> Tuple[List[Dict[str, Any]
             if maxs:
                 st_entry["max_mm"] = max(maxs)
             entries.append(st_entry)
-            extracted["slice_thickness_mm"] = [st_entry.get("min_mm"), st_entry.get("max_mm")]
+            extracted["slice_thickness_mm"] = [
+                st_entry.get("min_mm"),
+                st_entry.get("max_mm"),
+            ]
         else:
             skipped.append("slice_thickness")
 
@@ -440,8 +466,7 @@ def model_card_to_yaml(model_card: Dict[str, Any]) -> str:
     entries, _ = _build_spec_entries(model_card)
 
     model_name: str = (
-        model_card.get("model_basic_information", {}).get("name", "")
-        or "unknown"
+        model_card.get("model_basic_information", {}).get("name", "") or "unknown"
     )
 
     header_lines = [
@@ -451,7 +476,9 @@ def model_card_to_yaml(model_card: Dict[str, Any]) -> str:
     ]
 
     spec_dict: Dict[str, Any] = {"input": entries, "output": []}
-    yaml_body = yaml.dump(spec_dict, default_flow_style=False, allow_unicode=True, sort_keys=False)
+    yaml_body = yaml.dump(
+        spec_dict, default_flow_style=False, allow_unicode=True, sort_keys=False
+    )
 
     return "\n".join(header_lines) + yaml_body
 
@@ -479,7 +506,9 @@ def load_model_card(path: str | Path) -> Dict[str, Any]:
     with p.open("r", encoding="utf-8") as f:
         data = json.load(f)
     if not isinstance(data, dict):
-        raise ValueError(f"Expected a JSON object at top level, got {type(data).__name__}")
+        raise ValueError(
+            f"Expected a JSON object at top level, got {type(data).__name__}"
+        )
     return data
 
 

--- a/src/healthcare_ai_guardrails/model_card.py
+++ b/src/healthcare_ai_guardrails/model_card.py
@@ -1,0 +1,496 @@
+"""RT-AI-Model-Card integration for automatic guardrail spec generation.
+
+Parses an exported RT-AI-Model-Card JSON file
+(https://github.com/MIRO-UCLouvain/RT-AI-Model-Card) and converts it
+into a healthcare-ai-guardrails YAML spec that enforces the training
+data distribution at inference time.
+
+Example usage::
+
+    from healthcare_ai_guardrails.model_card import load_model_card, model_card_to_yaml
+
+    card = load_model_card("model_card.json")
+    yaml_spec = model_card_to_yaml(card)
+    print(yaml_spec)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from .config import load_spec_from_string, Spec
+
+# ---------------------------------------------------------------------------
+# Field parsers
+# ---------------------------------------------------------------------------
+
+# DICOM standard patient position codes
+_DICOM_POSITIONS = {"HFS", "HFP", "FFS", "FFP", "HFDR", "HFDL", "FFDR", "FFDL", "SITTING", "LLD", "RLD"}
+
+# Text-description → DICOM code mappings (lowercase keys)
+_POSITION_TEXT_MAP: Dict[str, str] = {
+    "head first supine": "HFS",
+    "head first prone": "HFP",
+    "feet first supine": "FFS",
+    "feet first prone": "FFP",
+    "head first decubitus right": "HFDR",
+    "head first decubitus left": "HFDL",
+    "feet first decubitus right": "FFDR",
+    "feet first decubitus left": "FFDL",
+}
+
+# Modality normalisation aliases (uppercase keys)
+_MODALITY_ALIASES: Dict[str, str] = {
+    "MRI": "MR",
+    "PET": "PT",
+    "XRAY": "DX",
+    "X-RAY": "DX",
+    "XRAY/CT": "DX",
+    "PET/CT": "PT",
+    "NUCLEAR MEDICINE": "NM",
+}
+
+
+def _parse_age_range(text: str) -> Tuple[Optional[float], Optional[float]]:
+    """Return (min_years, max_years) parsed from a free-text age description.
+
+    Supports patterns such as:
+    - "18-75 years", "18–75", "18 to 75 years"
+    - ">= 18 years", "≥18", "> 18"
+    - "<= 80 years", "≤80", "< 80 years"
+    - "adults (18+)"
+
+    Returns (None, None) if no age information can be extracted.
+    """
+    if not text or not text.strip():
+        return None, None
+
+    t = text.strip()
+
+    # Explicit range: "18-75 years" / "18 to 75" / "18–75"
+    range_match = re.search(
+        r"(\d+(?:\.\d+)?)\s*(?:-|–|—|to)\s*(\d+(?:\.\d+)?)\s*(?:years?|y\.?o\.?|yrs?)?",
+        t,
+        re.IGNORECASE,
+    )
+    if range_match:
+        lo, hi = float(range_match.group(1)), float(range_match.group(2))
+        return (lo, hi) if lo <= hi else (hi, lo)
+
+    # Lower bound only: ">= 18", "≥18", "> 18", "adults (18+)"
+    lower_match = re.search(
+        r"(?:[≥≧]|>=|>)\s*(\d+(?:\.\d+)?)\s*(?:years?|y\.?o\.?|yrs?)?|"
+        r"(\d+)\+\s*(?:years?|y\.?o\.?|yrs?)?",
+        t,
+        re.IGNORECASE,
+    )
+    if lower_match:
+        val = lower_match.group(1) or lower_match.group(2)
+        return float(val), None
+
+    # Upper bound only: "<= 80", "≤80", "< 80"
+    upper_match = re.search(
+        r"(?:[≤≦]|<=|<)\s*(\d+(?:\.\d+)?)\s*(?:years?|y\.?o\.?|yrs?)?",
+        t,
+        re.IGNORECASE,
+    )
+    if upper_match:
+        return None, float(upper_match.group(1))
+
+    return None, None
+
+
+def _parse_sex(text: str) -> List[str]:
+    """Return a list of DICOM sex codes parsed from a free-text description.
+
+    Recognised codes: M, F, O.
+    Returns empty list if nothing can be determined.
+    """
+    if not text or not text.strip():
+        return []
+
+    t = text.lower()
+    result: List[str] = []
+
+    # Shorthand patterns first (before keyword matching to avoid false positives)
+    # "M/F", "M, F", "M & F"
+    if re.search(r"\bm\s*[/,&]\s*f\b|\bf\s*[/,&]\s*m\b", t):
+        return ["M", "F"]
+    if re.search(r"\bm\s*[/,&]\s*f\s*[/,&]\s*o\b", t):
+        return ["M", "F", "O"]
+
+    # Keyword-based
+    has_male = bool(re.search(r"\bmale\b|\bmen\b|\bman\b", t))
+    has_female = bool(re.search(r"\bfemale\b|\bwomen\b|\bwoman\b", t))
+    has_both = bool(re.search(r"\bboth\b|\ball\b|\bmix", t))
+    has_other = bool(re.search(r"\bother\b", t))
+
+    if has_both or (has_male and has_female):
+        result = ["M", "F"]
+    elif has_male:
+        result = ["M"]
+    elif has_female:
+        result = ["F"]
+    else:
+        # Try single-letter codes: standalone "M" or "F"
+        if re.search(r"\bm\b", t):
+            result.append("M")
+        if re.search(r"\bf\b", t):
+            result.append("F")
+
+    if has_other and "O" not in result:
+        result.append("O")
+
+    return result
+
+
+def _parse_modalities(model_card: Dict[str, Any]) -> List[str]:
+    """Extract and normalise modality codes from technical_specifications.model_inputs."""
+    tech = model_card.get("technical_specifications", {})
+    raw: Any = tech.get("model_inputs", [])
+
+    if not isinstance(raw, list):
+        return []
+
+    normalised: List[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        code = item.strip().upper()
+        code = _MODALITY_ALIASES.get(code, code)
+        if code and code not in normalised:
+            normalised.append(code)
+
+    return normalised
+
+
+def _parse_patient_positions(text: str) -> List[str]:
+    """Extract DICOM patient position codes from a free-text string.
+
+    Recognises standard 4-letter codes (HFS, HFP, …) and common
+    natural-language descriptions.
+    """
+    if not text or not text.strip():
+        return []
+
+    t = text.strip()
+    found: List[str] = []
+
+    # Try natural-language descriptions first (longest match first)
+    t_lower = t.lower()
+    for desc, code in sorted(_POSITION_TEXT_MAP.items(), key=lambda x: -len(x[0])):
+        if desc in t_lower and code not in found:
+            found.append(code)
+
+    # Extract standard uppercase codes
+    for code in re.findall(r"\b(HFS|HFP|FFS|FFP|HFDR|HFDL|FFDR|FFDL|SITTING|LLD|RLD)\b", t, re.IGNORECASE):
+        upper = code.upper()
+        if upper not in found:
+            found.append(upper)
+
+    return found
+
+
+def _parse_slice_thickness(text: str) -> Tuple[Optional[float], Optional[float]]:
+    """Extract a slice thickness range (mm) from free-text acquisition parameters.
+
+    Supports:
+    - "slice thickness: 1-3mm", "slice thickness 1.5mm"
+    - "1mm slice", "3 mm slices"
+    - "1-3 mm"
+    """
+    if not text or not text.strip():
+        return None, None
+
+    t = text
+
+    # "slice thickness: 1-3mm" or "slice thickness 1 to 3 mm"
+    range_match = re.search(
+        r"slice\s*(?:thickness)?\s*:?\s*(\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(\d+(?:\.\d+)?)\s*mm",
+        t,
+        re.IGNORECASE,
+    )
+    if range_match:
+        lo, hi = float(range_match.group(1)), float(range_match.group(2))
+        return (lo, hi) if lo <= hi else (hi, lo)
+
+    # Single value: "slice thickness: 1.5mm"
+    single_match = re.search(
+        r"slice\s*(?:thickness)?\s*:?\s*(\d+(?:\.\d+)?)\s*mm",
+        t,
+        re.IGNORECASE,
+    )
+    if single_match:
+        val = float(single_match.group(1))
+        return val, val
+
+    # "1mm slice" / "3mm slices"
+    mm_slice_match = re.search(
+        r"(\d+(?:\.\d+)?)\s*mm\s*(?:slices?|thick)",
+        t,
+        re.IGNORECASE,
+    )
+    if mm_slice_match:
+        val = float(mm_slice_match.group(1))
+        return val, val
+
+    return None, None
+
+
+def _parse_kvp(text: str) -> Tuple[Optional[float], Optional[float]]:
+    """Extract a kVp range from free-text acquisition parameters.
+
+    Supports:
+    - "120 kVp", "kVp: 120", "100-140 kVp", "kVp 100-140"
+    """
+    if not text or not text.strip():
+        return None, None
+
+    t = text
+
+    # "100-140 kVp" or "kVp: 100-140"
+    range_match = re.search(
+        r"(\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(\d+(?:\.\d+)?)\s*k[Vv][Pp]|"
+        r"k[Vv][Pp]\s*:?\s*(\d+(?:\.\d+)?)\s*(?:-|–|to)\s*(\d+(?:\.\d+)?)",
+        t,
+        re.IGNORECASE,
+    )
+    if range_match:
+        if range_match.group(1):
+            lo, hi = float(range_match.group(1)), float(range_match.group(2))
+        else:
+            lo, hi = float(range_match.group(3)), float(range_match.group(4))
+        return (lo, hi) if lo <= hi else (hi, lo)
+
+    # Single value: "120 kVp" or "kVp: 120"
+    single_match = re.search(
+        r"(\d+(?:\.\d+)?)\s*k[Vv][Pp]|k[Vv][Pp]\s*:?\s*(\d+(?:\.\d+)?)",
+        t,
+        re.IGNORECASE,
+    )
+    if single_match:
+        val = float(single_match.group(1) or single_match.group(2))
+        return val, val
+
+    return None, None
+
+
+# ---------------------------------------------------------------------------
+# Spec/YAML generation
+# ---------------------------------------------------------------------------
+
+def _build_spec_entries(model_card: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Build a list of validator dicts and an extraction summary from a model card.
+
+    Returns (entries, extracted_summary).
+    """
+    entries: List[Dict[str, Any]] = []
+    extracted: Dict[str, Any] = {}
+    skipped: List[str] = []
+
+    training = model_card.get("training_data", {})
+    model_name: str = (
+        model_card.get("model_basic_information", {}).get("name", "")
+        or model_card.get("card_metadata", {}).get("version_number", "")
+        or "unknown"
+    )
+
+    # --- Modality ---
+    modalities = _parse_modalities(model_card)
+    if modalities:
+        entries.append({
+            "type": "dicom_modality",
+            "name": "allowed_modality",
+            "description": f"Modality must match training data for model: {model_name}",
+            "allowed": modalities,
+            "severity": "error",
+        })
+        extracted["modalities"] = modalities
+    else:
+        skipped.append("modalities")
+
+    # --- Age ---
+    age_text = str(training.get("age", "") or "")
+    min_age, max_age = _parse_age_range(age_text)
+    if min_age is not None or max_age is not None:
+        entry: Dict[str, Any] = {
+            "type": "dicom_patient_age",
+            "name": "age_in_training_bounds",
+            "description": f"Patient age within training distribution ({age_text.strip()})",
+            "severity": "warning",
+        }
+        if min_age is not None:
+            entry["min_years"] = min_age
+        if max_age is not None:
+            entry["max_years"] = max_age
+        entries.append(entry)
+        extracted["age_range"] = [min_age, max_age]
+    else:
+        skipped.append("age")
+
+    # --- Sex ---
+    sex_text = str(training.get("sex", "") or "")
+    sex_codes = _parse_sex(sex_text)
+    if sex_codes:
+        entries.append({
+            "type": "dicom_patient_sex",
+            "name": "allowed_patient_sex",
+            "description": f"Patient sex within training distribution ({sex_text.strip()})",
+            "allowed": sex_codes,
+            "severity": "warning",
+        })
+        extracted["sex"] = sex_codes
+    else:
+        skipped.append("sex")
+
+    # --- Per-modality scan parameters ---
+    io_specs: Any = training.get("inputs_outputs_technical_specifications", [])
+    if isinstance(io_specs, list):
+        all_positions: List[str] = []
+        all_slice_thicknesses: List[Tuple[Optional[float], Optional[float]]] = []
+        all_kvps: List[Tuple[Optional[float], Optional[float]]] = []
+
+        for spec_item in io_specs:
+            if not isinstance(spec_item, dict):
+                continue
+            if spec_item.get("source") != "model_inputs":
+                continue
+
+            pos_text = str(spec_item.get("patient_positioning", "") or "")
+            positions = _parse_patient_positions(pos_text)
+            for p in positions:
+                if p not in all_positions:
+                    all_positions.append(p)
+
+            acq_text = str(spec_item.get("scan_acquisition_parameters", "") or "")
+            st_range = _parse_slice_thickness(acq_text)
+            if st_range != (None, None):
+                all_slice_thicknesses.append(st_range)
+
+            kvp_range = _parse_kvp(acq_text)
+            if kvp_range != (None, None):
+                all_kvps.append(kvp_range)
+
+        if all_positions:
+            entries.append({
+                "type": "dicom_patient_position",
+                "name": "allowed_patient_position",
+                "description": "Patient position must match training data",
+                "allowed": all_positions,
+                "severity": "warning",
+            })
+            extracted["patient_positions"] = all_positions
+        else:
+            skipped.append("patient_positioning")
+
+        if all_slice_thicknesses:
+            # Use the broadest range across all modalities
+            mins = [lo for lo, _ in all_slice_thicknesses if lo is not None]
+            maxs = [hi for _, hi in all_slice_thicknesses if hi is not None]
+            st_entry: Dict[str, Any] = {
+                "type": "dicom_slice_thickness",
+                "name": "slice_thickness_in_training_bounds",
+                "description": "Slice thickness within training distribution",
+                "severity": "warning",
+            }
+            if mins:
+                st_entry["min_mm"] = min(mins)
+            if maxs:
+                st_entry["max_mm"] = max(maxs)
+            entries.append(st_entry)
+            extracted["slice_thickness_mm"] = [st_entry.get("min_mm"), st_entry.get("max_mm")]
+        else:
+            skipped.append("slice_thickness")
+
+        if all_kvps:
+            mins_kvp = [lo for lo, _ in all_kvps if lo is not None]
+            maxs_kvp = [hi for _, hi in all_kvps if hi is not None]
+            kvp_entry: Dict[str, Any] = {
+                "type": "dicom_kvp",
+                "name": "kvp_in_training_bounds",
+                "description": "kVp within training distribution",
+                "severity": "warning",
+            }
+            if mins_kvp:
+                kvp_entry["min_kvp"] = min(mins_kvp)
+            if maxs_kvp:
+                kvp_entry["max_kvp"] = max(maxs_kvp)
+            entries.append(kvp_entry)
+            extracted["kvp"] = [kvp_entry.get("min_kvp"), kvp_entry.get("max_kvp")]
+        else:
+            skipped.append("kvp")
+
+    extracted["skipped_fields"] = skipped
+    return entries, extracted
+
+
+def model_card_to_yaml(model_card: Dict[str, Any]) -> str:
+    """Convert an RT-AI-Model-Card dict into a guardrail YAML spec string.
+
+    Fields that cannot be reliably parsed from free text are silently skipped.
+
+    :param model_card: Parsed RT-AI-Model-Card JSON as a dict.
+    :return: YAML string suitable for use with :func:`load_spec_from_string`.
+    """
+    entries, _ = _build_spec_entries(model_card)
+
+    model_name: str = (
+        model_card.get("model_basic_information", {}).get("name", "")
+        or "unknown"
+    )
+
+    header_lines = [
+        f"# Auto-generated from RT-AI-Model-Card: {model_name}",
+        "# Edit as needed before use in production.",
+        "",
+    ]
+
+    spec_dict: Dict[str, Any] = {"input": entries, "output": []}
+    yaml_body = yaml.dump(spec_dict, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    return "\n".join(header_lines) + yaml_body
+
+
+def model_card_to_spec(model_card: Dict[str, Any]) -> Spec:
+    """Convert an RT-AI-Model-Card dict into a :class:`Spec` object.
+
+    :param model_card: Parsed RT-AI-Model-Card JSON as a dict.
+    :return: A :class:`~healthcare_ai_guardrails.config.Spec` ready for use
+        with :class:`~healthcare_ai_guardrails.runner.GuardrailRunner`.
+    """
+    yaml_str = model_card_to_yaml(model_card)
+    return load_spec_from_string(yaml_str)
+
+
+def load_model_card(path: str | Path) -> Dict[str, Any]:
+    """Load an RT-AI-Model-Card JSON export from *path*.
+
+    :param path: Path to a ``.json`` file exported from the RT-AI-Model-Card
+        tool (https://github.com/MIRO-UCLouvain/RT-AI-Model-Card).
+    :return: The model card as a plain Python dict.
+    :raises ValueError: If the file is not valid JSON or not a JSON object.
+    """
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a JSON object at top level, got {type(data).__name__}")
+    return data
+
+
+def model_card_to_extraction_summary(model_card: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a summary of what was extracted from the model card.
+
+    Useful for debugging or for the MCP tool response.
+
+    :param model_card: Parsed RT-AI-Model-Card JSON as a dict.
+    :return: Dict with keys ``extracted`` and ``skipped_fields``.
+    """
+    _, extracted = _build_spec_entries(model_card)
+    skipped = extracted.pop("skipped_fields", [])
+    return {"extracted": extracted, "skipped_fields": skipped}

--- a/src/healthcare_ai_guardrails/model_card.py
+++ b/src/healthcare_ai_guardrails/model_card.py
@@ -29,7 +29,7 @@ from .config import load_spec_from_string, Spec
 # Field parsers
 # ---------------------------------------------------------------------------
 
-# DICOM standard patient position codes
+# DICOM standard patient position codes (used both for the text-map and regex)
 _DICOM_POSITIONS = {
     "HFS",
     "HFP",
@@ -44,6 +44,13 @@ _DICOM_POSITIONS = {
     "RLD",
 }
 
+# Pre-compiled regex built from _DICOM_POSITIONS so the two stay in sync.
+# Longer codes are tried first to avoid partial matches (e.g. "HFS" before "HF").
+_POSITION_PATTERN = re.compile(
+    r"\b(" + "|".join(sorted(_DICOM_POSITIONS, key=len, reverse=True)) + r")\b",
+    re.IGNORECASE,
+)
+
 # Text-description → DICOM code mappings (lowercase keys)
 _POSITION_TEXT_MAP: Dict[str, str] = {
     "head first supine": "HFS",
@@ -56,14 +63,14 @@ _POSITION_TEXT_MAP: Dict[str, str] = {
     "feet first decubitus left": "FFDL",
 }
 
-# Modality normalisation aliases (uppercase keys)
+# Modality normalisation aliases (uppercase keys).
+# Compound strings like "PET/CT" are split on "/" before lookup so both
+# components are preserved — do NOT add compound keys here.
 _MODALITY_ALIASES: Dict[str, str] = {
     "MRI": "MR",
     "PET": "PT",
     "XRAY": "DX",
     "X-RAY": "DX",
-    "XRAY/CT": "DX",
-    "PET/CT": "PT",
     "NUCLEAR MEDICINE": "NM",
 }
 
@@ -139,7 +146,9 @@ def _parse_sex(text: str) -> List[str]:
     # Keyword-based
     has_male = bool(re.search(r"\bmale\b|\bmen\b|\bman\b", t))
     has_female = bool(re.search(r"\bfemale\b|\bwomen\b|\bwoman\b", t))
-    has_both = bool(re.search(r"\bboth\b|\ball\b|\bmix", t))
+    # "both" alone is unambiguous; "all" is only safe when followed by
+    # "genders" or "sexes" (e.g. "all male" must NOT match).
+    has_both = bool(re.search(r"\bboth\b|\bmix|\ball\s+(?:genders?|sexes?)", t))
     has_other = bool(re.search(r"\bother\b", t))
 
     if has_both or (has_male and has_female):
@@ -162,17 +171,24 @@ def _parse_sex(text: str) -> List[str]:
 
 
 def _normalise_modality_list(raw: Any) -> List[str]:
-    """Normalise a raw list of modality strings to DICOM codes."""
+    """Normalise a raw list of modality strings to DICOM codes.
+
+    Compound strings like ``"PET/CT"`` are split on ``"/"`` before alias
+    lookup so that all modalities are preserved in the output
+    (``["PT", "CT"]`` rather than losing one of them).
+    """
     if not isinstance(raw, list):
         return []
     normalised: List[str] = []
     for item in raw:
         if not isinstance(item, str):
             continue
-        code = item.strip().upper()
-        code = _MODALITY_ALIASES.get(code, code)
-        if code and code not in normalised:
-            normalised.append(code)
+        # Split compound modalities (e.g. "PET/CT" → ["PET", "CT"])
+        for part in item.split("/"):
+            code = part.strip().upper()
+            code = _MODALITY_ALIASES.get(code, code)
+            if code and code not in normalised:
+                normalised.append(code)
     return normalised
 
 
@@ -206,10 +222,8 @@ def _parse_patient_positions(text: str) -> List[str]:
         if desc in t_lower and code not in found:
             found.append(code)
 
-    # Extract standard uppercase codes
-    for code in re.findall(
-        r"\b(HFS|HFP|FFS|FFP|HFDR|HFDL|FFDR|FFDL|SITTING|LLD|RLD)\b", t, re.IGNORECASE
-    ):
+    # Extract standard uppercase codes using the pre-compiled pattern
+    for code in _POSITION_PATTERN.findall(t):
         upper = code.upper()
         if upper not in found:
             found.append(upper)
@@ -547,6 +561,9 @@ def model_card_to_yaml(model_card: Dict[str, Any]) -> str:
     model_name: str = (
         model_card.get("model_basic_information", {}).get("name", "") or "unknown"
     )
+    # Sanitize: a newline in the name would break the YAML comment and could
+    # inject arbitrary content into the generated spec.
+    model_name = model_name.replace("\r", " ").replace("\n", " ")
 
     header_lines = [
         f"# Auto-generated from RT-AI-Model-Card: {model_name}",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import textwrap
 
+import json
+
 from healthcare_ai_guardrails.mcp_server import (
     describe_spec,
+    generate_spec_from_model_card,
     list_validator_types,
     run_guardrails,
     validate_spec,
@@ -305,4 +308,58 @@ class TestDescribeSpec:
 
     def test_error_on_bad_spec(self):
         result = describe_spec(spec_yaml=INVALID_SPEC)
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# generate_spec_from_model_card tests
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CARD = {
+    "task": "Segmentation",
+    "model_basic_information": {"name": "TestModel"},
+    "technical_specifications": {
+        "model_inputs": ["CT"],
+        "model_outputs": ["RTSTRUCT"],
+    },
+    "training_data": {
+        "age": "18-75 years",
+        "sex": "Male and Female",
+        "inputs_outputs_technical_specifications": [
+            {
+                "entry": "CT",
+                "source": "model_inputs",
+                "patient_positioning": "HFS",
+                "scan_acquisition_parameters": "kVp: 120, slice thickness: 1-3mm",
+            }
+        ],
+    },
+}
+
+
+class TestGenerateSpecFromModelCard:
+    def test_valid_card_returns_yaml(self):
+        result = generate_spec_from_model_card(json.dumps(_SAMPLE_CARD))
+        assert "yaml" in result
+        assert "CT" in result["yaml"]
+        assert "dicom_modality" in result["yaml"]
+
+    def test_extracted_fields_present(self):
+        result = generate_spec_from_model_card(json.dumps(_SAMPLE_CARD))
+        assert "extracted" in result
+        assert result["extracted"]["modalities"] == ["CT"]
+        assert result["extracted"]["age_range"] == [18.0, 75.0]
+
+    def test_skipped_fields_present(self):
+        result = generate_spec_from_model_card(json.dumps(_SAMPLE_CARD))
+        assert "skipped_fields" in result
+        assert isinstance(result["skipped_fields"], list)
+
+    def test_invalid_json_returns_error(self):
+        result = generate_spec_from_model_card("not valid json {{")
+        assert "error" in result
+        assert "JSON" in result["error"]
+
+    def test_non_object_json_returns_error(self):
+        result = generate_spec_from_model_card(json.dumps([1, 2, 3]))
         assert "error" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -331,6 +331,7 @@ _SAMPLE_CARD = {
                 "source": "model_inputs",
                 "patient_positioning": "HFS",
                 "scan_acquisition_parameters": "kVp: 120, slice thickness: 1-3mm",
+                "scanner_model": "Siemens SOMATOM Definition AS+",
             }
         ],
     },
@@ -349,6 +350,16 @@ class TestGenerateSpecFromModelCard:
         assert "extracted" in result
         assert result["extracted"]["modalities"] == ["CT"]
         assert result["extracted"]["age_range"] == [18.0, 75.0]
+        assert result["extracted"]["output_modalities"] == ["RTSTRUCT"]
+        assert "Siemens SOMATOM Definition AS+" in result["extracted"]["scanner_models"]
+
+    def test_output_modality_in_yaml(self):
+        result = generate_spec_from_model_card(json.dumps(_SAMPLE_CARD))
+        import yaml as _yaml
+
+        parsed = _yaml.safe_load(result["yaml"])
+        assert len(parsed["output"]) == 1
+        assert "RTSTRUCT" in parsed["output"][0]["allowed"]
 
     def test_skipped_fields_present(self):
         result = generate_spec_from_model_card(json.dumps(_SAMPLE_CARD))

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -1,0 +1,440 @@
+"""Tests for the RT-AI-Model-Card integration (model_card.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import yaml
+
+from healthcare_ai_guardrails.model_card import (
+    _parse_age_range,
+    _parse_kvp,
+    _parse_modalities,
+    _parse_patient_positions,
+    _parse_sex,
+    _parse_slice_thickness,
+    load_model_card,
+    model_card_to_spec,
+    model_card_to_yaml,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sample_model_card() -> Dict[str, Any]:
+    return {
+        "task": "Segmentation",
+        "model_basic_information": {"name": "TestModel"},
+        "technical_specifications": {
+            "model_inputs": ["CT"],
+            "model_outputs": ["RTSTRUCT"],
+        },
+        "training_data": {
+            "age": "18-75 years",
+            "sex": "Male and Female",
+            "inputs_outputs_technical_specifications": [
+                {
+                    "entry": "CT",
+                    "source": "model_inputs",
+                    "patient_positioning": "HFS",
+                    "scan_acquisition_parameters": "kVp: 120, slice thickness: 1-3mm",
+                    "image_resolution": "512x512",
+                }
+            ],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# _parse_age_range
+# ---------------------------------------------------------------------------
+
+class TestParseAgeRange:
+    def test_dash_range_years(self):
+        assert _parse_age_range("18-75 years") == (18.0, 75.0)
+
+    def test_dash_range_no_unit(self):
+        assert _parse_age_range("18-75") == (18.0, 75.0)
+
+    def test_to_range(self):
+        assert _parse_age_range("18 to 75 years") == (18.0, 75.0)
+
+    def test_en_dash_range(self):
+        assert _parse_age_range("20–80 years") == (20.0, 80.0)
+
+    def test_lower_bound_gte(self):
+        lo, hi = _parse_age_range(">= 18 years")
+        assert lo == 18.0
+        assert hi is None
+
+    def test_lower_bound_unicode_gte(self):
+        lo, hi = _parse_age_range("≥18 years")
+        assert lo == 18.0
+        assert hi is None
+
+    def test_lower_bound_gt(self):
+        lo, hi = _parse_age_range("> 18")
+        assert lo == 18.0
+        assert hi is None
+
+    def test_upper_bound_lt(self):
+        lo, hi = _parse_age_range("< 80 years")
+        assert lo is None
+        assert hi == 80.0
+
+    def test_upper_bound_lte_unicode(self):
+        lo, hi = _parse_age_range("≤80")
+        assert lo is None
+        assert hi == 80.0
+
+    def test_empty_string(self):
+        assert _parse_age_range("") == (None, None)
+
+    def test_unparseable(self):
+        assert _parse_age_range("adults only") == (None, None)
+
+    def test_decimal(self):
+        lo, hi = _parse_age_range("0.5-2.5 years")
+        assert lo == 0.5
+        assert hi == 2.5
+
+    def test_reversed_range_normalised(self):
+        # Parser should always return (min, max) regardless of input order
+        lo, hi = _parse_age_range("75-18 years")
+        assert lo == 18.0
+        assert hi == 75.0
+
+
+# ---------------------------------------------------------------------------
+# _parse_sex
+# ---------------------------------------------------------------------------
+
+class TestParseSex:
+    def test_male_and_female(self):
+        assert _parse_sex("Male and Female") == ["M", "F"]
+
+    def test_both_sexes(self):
+        assert _parse_sex("both sexes") == ["M", "F"]
+
+    def test_all_genders(self):
+        result = _parse_sex("All genders")
+        assert "M" in result and "F" in result
+
+    def test_shorthand_m_f(self):
+        assert _parse_sex("M/F") == ["M", "F"]
+
+    def test_shorthand_m_comma_f(self):
+        assert _parse_sex("M, F") == ["M", "F"]
+
+    def test_female_only(self):
+        assert _parse_sex("Female only") == ["F"]
+
+    def test_male_only(self):
+        assert _parse_sex("male patients") == ["M"]
+
+    def test_other_included(self):
+        result = _parse_sex("Male, Female, and Other")
+        assert set(result) == {"M", "F", "O"}
+
+    def test_empty(self):
+        assert _parse_sex("") == []
+
+    def test_women(self):
+        assert _parse_sex("women") == ["F"]
+
+    def test_men(self):
+        assert _parse_sex("men") == ["M"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_modalities
+# ---------------------------------------------------------------------------
+
+class TestParseModalities:
+    def test_single_ct(self):
+        card = {"technical_specifications": {"model_inputs": ["CT"]}}
+        assert _parse_modalities(card) == ["CT"]
+
+    def test_normalise_mri(self):
+        card = {"technical_specifications": {"model_inputs": ["MRI"]}}
+        assert _parse_modalities(card) == ["MR"]
+
+    def test_normalise_pet(self):
+        card = {"technical_specifications": {"model_inputs": ["PET"]}}
+        assert _parse_modalities(card) == ["PT"]
+
+    def test_multiple_with_normalisation(self):
+        card = {"technical_specifications": {"model_inputs": ["MRI", "CT"]}}
+        result = _parse_modalities(card)
+        assert set(result) == {"MR", "CT"}
+
+    def test_empty_list(self):
+        card = {"technical_specifications": {"model_inputs": []}}
+        assert _parse_modalities(card) == []
+
+    def test_missing_key(self):
+        assert _parse_modalities({}) == []
+
+    def test_deduplication(self):
+        card = {"technical_specifications": {"model_inputs": ["CT", "CT"]}}
+        assert _parse_modalities(card) == ["CT"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_patient_positions
+# ---------------------------------------------------------------------------
+
+class TestParsePatientPositions:
+    def test_standard_code(self):
+        assert _parse_patient_positions("HFS") == ["HFS"]
+
+    def test_multiple_codes(self):
+        result = _parse_patient_positions("HFS, FFP")
+        assert set(result) == {"HFS", "FFP"}
+
+    def test_natural_language_hfs(self):
+        result = _parse_patient_positions("Head First Supine")
+        assert "HFS" in result
+
+    def test_natural_language_ffp(self):
+        result = _parse_patient_positions("Feet First Prone")
+        assert "FFP" in result
+
+    def test_case_insensitive_code(self):
+        result = _parse_patient_positions("hfs")
+        assert "HFS" in result
+
+    def test_empty(self):
+        assert _parse_patient_positions("") == []
+
+    def test_unparseable(self):
+        assert _parse_patient_positions("standard positioning") == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_slice_thickness
+# ---------------------------------------------------------------------------
+
+class TestParseSliceThickness:
+    def test_range_mm(self):
+        assert _parse_slice_thickness("slice thickness: 1-3mm") == (1.0, 3.0)
+
+    def test_range_with_to(self):
+        assert _parse_slice_thickness("slice thickness 1 to 3 mm") == (1.0, 3.0)
+
+    def test_single_value(self):
+        assert _parse_slice_thickness("slice thickness: 1.5mm") == (1.5, 1.5)
+
+    def test_mm_slice_suffix(self):
+        assert _parse_slice_thickness("3mm slices") == (3.0, 3.0)
+
+    def test_in_mixed_text(self):
+        lo, hi = _parse_slice_thickness("kVp: 120, slice thickness: 1-3mm, FOV: 500mm")
+        assert lo == 1.0
+        assert hi == 3.0
+
+    def test_no_match(self):
+        assert _parse_slice_thickness("kVp: 120") == (None, None)
+
+    def test_empty(self):
+        assert _parse_slice_thickness("") == (None, None)
+
+    def test_reversed_normalised(self):
+        lo, hi = _parse_slice_thickness("slice thickness: 3-1mm")
+        assert lo == 1.0
+        assert hi == 3.0
+
+
+# ---------------------------------------------------------------------------
+# _parse_kvp
+# ---------------------------------------------------------------------------
+
+class TestParseKvp:
+    def test_single_kvp(self):
+        assert _parse_kvp("120 kVp") == (120.0, 120.0)
+
+    def test_kvp_colon(self):
+        assert _parse_kvp("kVp: 120") == (120.0, 120.0)
+
+    def test_range_kvp(self):
+        assert _parse_kvp("100-140 kVp") == (100.0, 140.0)
+
+    def test_kvp_range_colon(self):
+        assert _parse_kvp("kVp: 100-140") == (100.0, 140.0)
+
+    def test_in_mixed_text(self):
+        lo, hi = _parse_kvp("kVp: 120, slice thickness: 1-3mm")
+        assert lo == 120.0
+        assert hi == 120.0
+
+    def test_no_match(self):
+        assert _parse_kvp("slice thickness: 1.5mm") == (None, None)
+
+    def test_empty(self):
+        assert _parse_kvp("") == (None, None)
+
+    def test_case_insensitive(self):
+        assert _parse_kvp("120 KVP") == (120.0, 120.0)
+
+    def test_reversed_normalised(self):
+        lo, hi = _parse_kvp("140-100 kVp")
+        assert lo == 100.0
+        assert hi == 140.0
+
+
+# ---------------------------------------------------------------------------
+# model_card_to_yaml
+# ---------------------------------------------------------------------------
+
+class TestModelCardToYaml:
+    def test_returns_valid_yaml(self):
+        card = _sample_model_card()
+        result = model_card_to_yaml(card)
+        parsed = yaml.safe_load(result)
+        assert isinstance(parsed, dict)
+        assert "input" in parsed
+
+    def test_contains_modality_validator(self):
+        card = _sample_model_card()
+        result = model_card_to_yaml(card)
+        parsed = yaml.safe_load(result)
+        types = [v["type"] for v in parsed["input"]]
+        assert "dicom_modality" in types
+
+    def test_modality_has_ct(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        modality_v = next(v for v in parsed["input"] if v["type"] == "dicom_modality")
+        assert "CT" in modality_v["allowed"]
+
+    def test_age_validator_present(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        types = [v["type"] for v in parsed["input"]]
+        assert "dicom_patient_age" in types
+
+    def test_age_validator_bounds(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        age_v = next(v for v in parsed["input"] if v["type"] == "dicom_patient_age")
+        assert age_v["min_years"] == 18.0
+        assert age_v["max_years"] == 75.0
+
+    def test_sex_validator_present(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        types = [v["type"] for v in parsed["input"]]
+        assert "dicom_patient_sex" in types
+
+    def test_patient_position_validator(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        types = [v["type"] for v in parsed["input"]]
+        assert "dicom_patient_position" in types
+
+    def test_slice_thickness_validator(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        types = [v["type"] for v in parsed["input"]]
+        assert "dicom_slice_thickness" in types
+
+    def test_kvp_validator(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        types = [v["type"] for v in parsed["input"]]
+        assert "dicom_kvp" in types
+
+    def test_empty_training_data_produces_minimal_spec(self):
+        card: Dict[str, Any] = {
+            "technical_specifications": {"model_inputs": []},
+            "training_data": {},
+        }
+        result = model_card_to_yaml(card)
+        parsed = yaml.safe_load(result)
+        assert parsed["input"] == []
+
+    def test_header_comment_present(self):
+        card = _sample_model_card()
+        result = model_card_to_yaml(card)
+        assert result.startswith("#")
+
+    def test_modality_severity_is_error(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        modality_v = next(v for v in parsed["input"] if v["type"] == "dicom_modality")
+        assert modality_v["severity"] == "error"
+
+    def test_age_severity_is_warning(self):
+        card = _sample_model_card()
+        parsed = yaml.safe_load(model_card_to_yaml(card))
+        age_v = next(v for v in parsed["input"] if v["type"] == "dicom_patient_age")
+        assert age_v["severity"] == "warning"
+
+
+# ---------------------------------------------------------------------------
+# model_card_to_spec
+# ---------------------------------------------------------------------------
+
+class TestModelCardToSpec:
+    def test_returns_spec_with_input_validators(self):
+        from healthcare_ai_guardrails.config import Spec
+
+        card = _sample_model_card()
+        spec = model_card_to_spec(card)
+        assert isinstance(spec, Spec)
+        assert len(spec.input_validators) > 0
+
+    def test_output_validators_empty(self):
+        card = _sample_model_card()
+        spec = model_card_to_spec(card)
+        assert spec.output_validators == []
+
+    def test_modality_validator_has_ct(self):
+        from healthcare_ai_guardrails.validators.dicom import DICOMModalityCheck
+
+        card = _sample_model_card()
+        spec = model_card_to_spec(card)
+        modality_validators = [v for v in spec.input_validators if isinstance(v, DICOMModalityCheck)]
+        assert len(modality_validators) == 1
+        assert "CT" in modality_validators[0].allowed_modalities
+
+    def test_age_validator_bounds(self):
+        from healthcare_ai_guardrails.validators.dicom import DICOMPatientAgeCheck
+
+        card = _sample_model_card()
+        spec = model_card_to_spec(card)
+        age_validators = [v for v in spec.input_validators if isinstance(v, DICOMPatientAgeCheck)]
+        assert len(age_validators) == 1
+        assert age_validators[0].min_years == 18.0
+        assert age_validators[0].max_years == 75.0
+
+
+# ---------------------------------------------------------------------------
+# load_model_card
+# ---------------------------------------------------------------------------
+
+class TestLoadModelCard:
+    def test_loads_json_from_file(self, tmp_path: Path):
+        card = _sample_model_card()
+        p = tmp_path / "model_card.json"
+        p.write_text(json.dumps(card), encoding="utf-8")
+        loaded = load_model_card(p)
+        assert loaded["task"] == "Segmentation"
+
+    def test_raises_on_non_object_json(self, tmp_path: Path):
+        p = tmp_path / "bad.json"
+        p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        with pytest.raises(ValueError, match="JSON object"):
+            load_model_card(p)
+
+    def test_accepts_string_path(self, tmp_path: Path):
+        card = _sample_model_card()
+        p = tmp_path / "model_card.json"
+        p.write_text(json.dumps(card), encoding="utf-8")
+        loaded = load_model_card(str(p))
+        assert isinstance(loaded, dict)

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -26,6 +26,7 @@ from healthcare_ai_guardrails.model_card import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _sample_model_card() -> Dict[str, Any]:
     return {
         "task": "Segmentation",
@@ -53,6 +54,7 @@ def _sample_model_card() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 # _parse_age_range
 # ---------------------------------------------------------------------------
+
 
 class TestParseAgeRange:
     @pytest.mark.parametrize("text", ["18-75 years", "18–75 years", "18 to 75 years"])
@@ -83,6 +85,7 @@ class TestParseAgeRange:
 # _parse_sex
 # ---------------------------------------------------------------------------
 
+
 class TestParseSex:
     def test_male_and_female_keywords(self):
         assert _parse_sex("Male and Female") == ["M", "F"]
@@ -110,20 +113,27 @@ class TestParseSex:
 # _parse_modalities
 # ---------------------------------------------------------------------------
 
+
 class TestParseModalities:
     def test_standard_code(self):
-        assert _parse_modalities({"technical_specifications": {"model_inputs": ["CT"]}}) == ["CT"]
+        assert _parse_modalities(
+            {"technical_specifications": {"model_inputs": ["CT"]}}
+        ) == ["CT"]
 
     @pytest.mark.parametrize("raw,expected", [("MRI", "MR"), ("PET", "PT")])
     def test_normalise_aliases(self, raw, expected):
-        assert _parse_modalities({"technical_specifications": {"model_inputs": [raw]}}) == [expected]
+        assert _parse_modalities(
+            {"technical_specifications": {"model_inputs": [raw]}}
+        ) == [expected]
 
     def test_multiple_with_normalisation(self):
         card = {"technical_specifications": {"model_inputs": ["MRI", "CT"]}}
         assert set(_parse_modalities(card)) == {"MR", "CT"}
 
     def test_empty_list_and_missing_key(self):
-        assert _parse_modalities({"technical_specifications": {"model_inputs": []}}) == []
+        assert (
+            _parse_modalities({"technical_specifications": {"model_inputs": []}}) == []
+        )
         assert _parse_modalities({}) == []
 
     def test_deduplication(self):
@@ -134,6 +144,7 @@ class TestParseModalities:
 # ---------------------------------------------------------------------------
 # _parse_patient_positions
 # ---------------------------------------------------------------------------
+
 
 class TestParsePatientPositions:
     def test_standard_code(self):
@@ -157,8 +168,11 @@ class TestParsePatientPositions:
 # _parse_slice_thickness
 # ---------------------------------------------------------------------------
 
+
 class TestParseSliceThickness:
-    @pytest.mark.parametrize("text", ["slice thickness: 1-3mm", "slice thickness 1 to 3 mm"])
+    @pytest.mark.parametrize(
+        "text", ["slice thickness: 1-3mm", "slice thickness 1 to 3 mm"]
+    )
     def test_range(self, text):
         assert _parse_slice_thickness(text) == (1.0, 3.0)
 
@@ -169,7 +183,9 @@ class TestParseSliceThickness:
         assert _parse_slice_thickness("3mm slices") == (3.0, 3.0)
 
     def test_in_mixed_text(self):
-        assert _parse_slice_thickness("kVp: 120, slice thickness: 1-3mm, FOV: 500mm") == (1.0, 3.0)
+        assert _parse_slice_thickness(
+            "kVp: 120, slice thickness: 1-3mm, FOV: 500mm"
+        ) == (1.0, 3.0)
 
     def test_reversed_normalised(self):
         assert _parse_slice_thickness("slice thickness: 3-1mm") == (1.0, 3.0)
@@ -182,6 +198,7 @@ class TestParseSliceThickness:
 # ---------------------------------------------------------------------------
 # _parse_kvp
 # ---------------------------------------------------------------------------
+
 
 class TestParseKvp:
     @pytest.mark.parametrize("text", ["120 kVp", "kVp: 120"])
@@ -210,6 +227,7 @@ class TestParseKvp:
 # model_card_to_yaml
 # ---------------------------------------------------------------------------
 
+
 class TestModelCardToYaml:
     def test_returns_valid_yaml_with_input_key(self):
         parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
@@ -235,10 +253,18 @@ class TestModelCardToYaml:
     def test_scan_param_validators_present(self):
         parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
         types = {v["type"] for v in parsed["input"]}
-        assert {"dicom_patient_sex", "dicom_patient_position", "dicom_slice_thickness", "dicom_kvp"}.issubset(types)
+        assert {
+            "dicom_patient_sex",
+            "dicom_patient_position",
+            "dicom_slice_thickness",
+            "dicom_kvp",
+        }.issubset(types)
 
     def test_empty_training_data_produces_minimal_spec(self):
-        card: Dict[str, Any] = {"technical_specifications": {"model_inputs": []}, "training_data": {}}
+        card: Dict[str, Any] = {
+            "technical_specifications": {"model_inputs": []},
+            "training_data": {},
+        }
         parsed = yaml.safe_load(model_card_to_yaml(card))
         assert parsed["input"] == []
 
@@ -246,6 +272,7 @@ class TestModelCardToYaml:
 # ---------------------------------------------------------------------------
 # model_card_to_spec
 # ---------------------------------------------------------------------------
+
 
 class TestModelCardToSpec:
     def test_returns_spec_with_validators(self):
@@ -257,19 +284,27 @@ class TestModelCardToSpec:
         assert spec.output_validators == []
 
     def test_validator_details(self):
-        from healthcare_ai_guardrails.validators.dicom import DICOMModalityCheck, DICOMPatientAgeCheck
+        from healthcare_ai_guardrails.validators.dicom import (
+            DICOMModalityCheck,
+            DICOMPatientAgeCheck,
+        )
 
         spec = model_card_to_spec(_sample_model_card())
-        modality_v = next(v for v in spec.input_validators if isinstance(v, DICOMModalityCheck))
+        modality_v = next(
+            v for v in spec.input_validators if isinstance(v, DICOMModalityCheck)
+        )
         assert "CT" in modality_v.allowed_modalities
 
-        age_v = next(v for v in spec.input_validators if isinstance(v, DICOMPatientAgeCheck))
+        age_v = next(
+            v for v in spec.input_validators if isinstance(v, DICOMPatientAgeCheck)
+        )
         assert age_v.min_years == 18.0 and age_v.max_years == 75.0
 
 
 # ---------------------------------------------------------------------------
 # load_model_card
 # ---------------------------------------------------------------------------
+
 
 class TestLoadModelCard:
     def test_loads_json_file(self, tmp_path: Path):

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -55,59 +55,28 @@ def _sample_model_card() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 class TestParseAgeRange:
-    def test_dash_range_years(self):
-        assert _parse_age_range("18-75 years") == (18.0, 75.0)
+    @pytest.mark.parametrize("text", ["18-75 years", "18–75 years", "18 to 75 years"])
+    def test_range_formats(self, text):
+        assert _parse_age_range(text) == (18.0, 75.0)
 
-    def test_dash_range_no_unit(self):
-        assert _parse_age_range("18-75") == (18.0, 75.0)
+    @pytest.mark.parametrize("text", [">= 18 years", "≥18"])
+    def test_lower_bound_only(self, text):
+        lo, hi = _parse_age_range(text)
+        assert lo == 18.0 and hi is None
 
-    def test_to_range(self):
-        assert _parse_age_range("18 to 75 years") == (18.0, 75.0)
-
-    def test_en_dash_range(self):
-        assert _parse_age_range("20–80 years") == (20.0, 80.0)
-
-    def test_lower_bound_gte(self):
-        lo, hi = _parse_age_range(">= 18 years")
-        assert lo == 18.0
-        assert hi is None
-
-    def test_lower_bound_unicode_gte(self):
-        lo, hi = _parse_age_range("≥18 years")
-        assert lo == 18.0
-        assert hi is None
-
-    def test_lower_bound_gt(self):
-        lo, hi = _parse_age_range("> 18")
-        assert lo == 18.0
-        assert hi is None
-
-    def test_upper_bound_lt(self):
+    def test_upper_bound_only(self):
         lo, hi = _parse_age_range("< 80 years")
-        assert lo is None
-        assert hi == 80.0
+        assert lo is None and hi == 80.0
 
-    def test_upper_bound_lte_unicode(self):
-        lo, hi = _parse_age_range("≤80")
-        assert lo is None
-        assert hi == 80.0
-
-    def test_empty_string(self):
-        assert _parse_age_range("") == (None, None)
-
-    def test_unparseable(self):
-        assert _parse_age_range("adults only") == (None, None)
-
-    def test_decimal(self):
-        lo, hi = _parse_age_range("0.5-2.5 years")
-        assert lo == 0.5
-        assert hi == 2.5
+    def test_decimal_range(self):
+        assert _parse_age_range("0.5-2.5 years") == (0.5, 2.5)
 
     def test_reversed_range_normalised(self):
-        # Parser should always return (min, max) regardless of input order
-        lo, hi = _parse_age_range("75-18 years")
-        assert lo == 18.0
-        assert hi == 75.0
+        assert _parse_age_range("75-18 years") == (18.0, 75.0)
+
+    def test_unparseable_returns_none(self):
+        assert _parse_age_range("adults only") == (None, None)
+        assert _parse_age_range("") == (None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -115,40 +84,26 @@ class TestParseAgeRange:
 # ---------------------------------------------------------------------------
 
 class TestParseSex:
-    def test_male_and_female(self):
+    def test_male_and_female_keywords(self):
         assert _parse_sex("Male and Female") == ["M", "F"]
 
-    def test_both_sexes(self):
-        assert _parse_sex("both sexes") == ["M", "F"]
-
-    def test_all_genders(self):
-        result = _parse_sex("All genders")
+    @pytest.mark.parametrize("text", ["both sexes", "All genders"])
+    def test_both_or_all(self, text):
+        result = _parse_sex(text)
         assert "M" in result and "F" in result
 
-    def test_shorthand_m_f(self):
+    def test_shorthand(self):
         assert _parse_sex("M/F") == ["M", "F"]
 
-    def test_shorthand_m_comma_f(self):
-        assert _parse_sex("M, F") == ["M", "F"]
-
-    def test_female_only(self):
-        assert _parse_sex("Female only") == ["F"]
-
-    def test_male_only(self):
-        assert _parse_sex("male patients") == ["M"]
+    @pytest.mark.parametrize("text,code", [("women", "F"), ("men", "M")])
+    def test_single_sex(self, text, code):
+        assert _parse_sex(text) == [code]
 
     def test_other_included(self):
-        result = _parse_sex("Male, Female, and Other")
-        assert set(result) == {"M", "F", "O"}
+        assert set(_parse_sex("Male, Female, and Other")) == {"M", "F", "O"}
 
     def test_empty(self):
         assert _parse_sex("") == []
-
-    def test_women(self):
-        assert _parse_sex("women") == ["F"]
-
-    def test_men(self):
-        assert _parse_sex("men") == ["M"]
 
 
 # ---------------------------------------------------------------------------
@@ -156,28 +111,19 @@ class TestParseSex:
 # ---------------------------------------------------------------------------
 
 class TestParseModalities:
-    def test_single_ct(self):
-        card = {"technical_specifications": {"model_inputs": ["CT"]}}
-        assert _parse_modalities(card) == ["CT"]
+    def test_standard_code(self):
+        assert _parse_modalities({"technical_specifications": {"model_inputs": ["CT"]}}) == ["CT"]
 
-    def test_normalise_mri(self):
-        card = {"technical_specifications": {"model_inputs": ["MRI"]}}
-        assert _parse_modalities(card) == ["MR"]
-
-    def test_normalise_pet(self):
-        card = {"technical_specifications": {"model_inputs": ["PET"]}}
-        assert _parse_modalities(card) == ["PT"]
+    @pytest.mark.parametrize("raw,expected", [("MRI", "MR"), ("PET", "PT")])
+    def test_normalise_aliases(self, raw, expected):
+        assert _parse_modalities({"technical_specifications": {"model_inputs": [raw]}}) == [expected]
 
     def test_multiple_with_normalisation(self):
         card = {"technical_specifications": {"model_inputs": ["MRI", "CT"]}}
-        result = _parse_modalities(card)
-        assert set(result) == {"MR", "CT"}
+        assert set(_parse_modalities(card)) == {"MR", "CT"}
 
-    def test_empty_list(self):
-        card = {"technical_specifications": {"model_inputs": []}}
-        assert _parse_modalities(card) == []
-
-    def test_missing_key(self):
+    def test_empty_list_and_missing_key(self):
+        assert _parse_modalities({"technical_specifications": {"model_inputs": []}}) == []
         assert _parse_modalities({}) == []
 
     def test_deduplication(self):
@@ -194,25 +140,16 @@ class TestParsePatientPositions:
         assert _parse_patient_positions("HFS") == ["HFS"]
 
     def test_multiple_codes(self):
-        result = _parse_patient_positions("HFS, FFP")
-        assert set(result) == {"HFS", "FFP"}
+        assert set(_parse_patient_positions("HFS, FFP")) == {"HFS", "FFP"}
 
-    def test_natural_language_hfs(self):
-        result = _parse_patient_positions("Head First Supine")
-        assert "HFS" in result
+    def test_natural_language(self):
+        assert "HFS" in _parse_patient_positions("Head First Supine")
 
-    def test_natural_language_ffp(self):
-        result = _parse_patient_positions("Feet First Prone")
-        assert "FFP" in result
+    def test_case_insensitive(self):
+        assert "HFS" in _parse_patient_positions("hfs")
 
-    def test_case_insensitive_code(self):
-        result = _parse_patient_positions("hfs")
-        assert "HFS" in result
-
-    def test_empty(self):
+    def test_empty_and_unparseable(self):
         assert _parse_patient_positions("") == []
-
-    def test_unparseable(self):
         assert _parse_patient_positions("standard positioning") == []
 
 
@@ -221,11 +158,9 @@ class TestParsePatientPositions:
 # ---------------------------------------------------------------------------
 
 class TestParseSliceThickness:
-    def test_range_mm(self):
-        assert _parse_slice_thickness("slice thickness: 1-3mm") == (1.0, 3.0)
-
-    def test_range_with_to(self):
-        assert _parse_slice_thickness("slice thickness 1 to 3 mm") == (1.0, 3.0)
+    @pytest.mark.parametrize("text", ["slice thickness: 1-3mm", "slice thickness 1 to 3 mm"])
+    def test_range(self, text):
+        assert _parse_slice_thickness(text) == (1.0, 3.0)
 
     def test_single_value(self):
         assert _parse_slice_thickness("slice thickness: 1.5mm") == (1.5, 1.5)
@@ -234,20 +169,14 @@ class TestParseSliceThickness:
         assert _parse_slice_thickness("3mm slices") == (3.0, 3.0)
 
     def test_in_mixed_text(self):
-        lo, hi = _parse_slice_thickness("kVp: 120, slice thickness: 1-3mm, FOV: 500mm")
-        assert lo == 1.0
-        assert hi == 3.0
+        assert _parse_slice_thickness("kVp: 120, slice thickness: 1-3mm, FOV: 500mm") == (1.0, 3.0)
+
+    def test_reversed_normalised(self):
+        assert _parse_slice_thickness("slice thickness: 3-1mm") == (1.0, 3.0)
 
     def test_no_match(self):
         assert _parse_slice_thickness("kVp: 120") == (None, None)
-
-    def test_empty(self):
         assert _parse_slice_thickness("") == (None, None)
-
-    def test_reversed_normalised(self):
-        lo, hi = _parse_slice_thickness("slice thickness: 3-1mm")
-        assert lo == 1.0
-        assert hi == 3.0
 
 
 # ---------------------------------------------------------------------------
@@ -255,36 +184,26 @@ class TestParseSliceThickness:
 # ---------------------------------------------------------------------------
 
 class TestParseKvp:
-    def test_single_kvp(self):
-        assert _parse_kvp("120 kVp") == (120.0, 120.0)
+    @pytest.mark.parametrize("text", ["120 kVp", "kVp: 120"])
+    def test_single_value(self, text):
+        assert _parse_kvp(text) == (120.0, 120.0)
 
-    def test_kvp_colon(self):
-        assert _parse_kvp("kVp: 120") == (120.0, 120.0)
-
-    def test_range_kvp(self):
-        assert _parse_kvp("100-140 kVp") == (100.0, 140.0)
-
-    def test_kvp_range_colon(self):
-        assert _parse_kvp("kVp: 100-140") == (100.0, 140.0)
-
-    def test_in_mixed_text(self):
-        lo, hi = _parse_kvp("kVp: 120, slice thickness: 1-3mm")
-        assert lo == 120.0
-        assert hi == 120.0
-
-    def test_no_match(self):
-        assert _parse_kvp("slice thickness: 1.5mm") == (None, None)
-
-    def test_empty(self):
-        assert _parse_kvp("") == (None, None)
+    @pytest.mark.parametrize("text", ["100-140 kVp", "kVp: 100-140"])
+    def test_range(self, text):
+        assert _parse_kvp(text) == (100.0, 140.0)
 
     def test_case_insensitive(self):
         assert _parse_kvp("120 KVP") == (120.0, 120.0)
 
+    def test_in_mixed_text(self):
+        assert _parse_kvp("kVp: 120, slice thickness: 1-3mm") == (120.0, 120.0)
+
     def test_reversed_normalised(self):
-        lo, hi = _parse_kvp("140-100 kVp")
-        assert lo == 100.0
-        assert hi == 140.0
+        assert _parse_kvp("140-100 kVp") == (100.0, 140.0)
+
+    def test_no_match(self):
+        assert _parse_kvp("slice thickness: 1.5mm") == (None, None)
+        assert _parse_kvp("") == (None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -292,88 +211,36 @@ class TestParseKvp:
 # ---------------------------------------------------------------------------
 
 class TestModelCardToYaml:
-    def test_returns_valid_yaml(self):
-        card = _sample_model_card()
-        result = model_card_to_yaml(card)
-        parsed = yaml.safe_load(result)
+    def test_returns_valid_yaml_with_input_key(self):
+        parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
         assert isinstance(parsed, dict)
         assert "input" in parsed
 
-    def test_contains_modality_validator(self):
-        card = _sample_model_card()
-        result = model_card_to_yaml(card)
-        parsed = yaml.safe_load(result)
-        types = [v["type"] for v in parsed["input"]]
-        assert "dicom_modality" in types
+    def test_header_comment_present(self):
+        assert model_card_to_yaml(_sample_model_card()).startswith("#")
 
-    def test_modality_has_ct(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
+    def test_modality_validator(self):
+        parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
         modality_v = next(v for v in parsed["input"] if v["type"] == "dicom_modality")
         assert "CT" in modality_v["allowed"]
+        assert modality_v["severity"] == "error"
 
-    def test_age_validator_present(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
-        types = [v["type"] for v in parsed["input"]]
-        assert "dicom_patient_age" in types
-
-    def test_age_validator_bounds(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
+    def test_age_validator(self):
+        parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
         age_v = next(v for v in parsed["input"] if v["type"] == "dicom_patient_age")
         assert age_v["min_years"] == 18.0
         assert age_v["max_years"] == 75.0
+        assert age_v["severity"] == "warning"
 
-    def test_sex_validator_present(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
-        types = [v["type"] for v in parsed["input"]]
-        assert "dicom_patient_sex" in types
-
-    def test_patient_position_validator(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
-        types = [v["type"] for v in parsed["input"]]
-        assert "dicom_patient_position" in types
-
-    def test_slice_thickness_validator(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
-        types = [v["type"] for v in parsed["input"]]
-        assert "dicom_slice_thickness" in types
-
-    def test_kvp_validator(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
-        types = [v["type"] for v in parsed["input"]]
-        assert "dicom_kvp" in types
+    def test_scan_param_validators_present(self):
+        parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
+        types = {v["type"] for v in parsed["input"]}
+        assert {"dicom_patient_sex", "dicom_patient_position", "dicom_slice_thickness", "dicom_kvp"}.issubset(types)
 
     def test_empty_training_data_produces_minimal_spec(self):
-        card: Dict[str, Any] = {
-            "technical_specifications": {"model_inputs": []},
-            "training_data": {},
-        }
-        result = model_card_to_yaml(card)
-        parsed = yaml.safe_load(result)
+        card: Dict[str, Any] = {"technical_specifications": {"model_inputs": []}, "training_data": {}}
+        parsed = yaml.safe_load(model_card_to_yaml(card))
         assert parsed["input"] == []
-
-    def test_header_comment_present(self):
-        card = _sample_model_card()
-        result = model_card_to_yaml(card)
-        assert result.startswith("#")
-
-    def test_modality_severity_is_error(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
-        modality_v = next(v for v in parsed["input"] if v["type"] == "dicom_modality")
-        assert modality_v["severity"] == "error"
-
-    def test_age_severity_is_warning(self):
-        card = _sample_model_card()
-        parsed = yaml.safe_load(model_card_to_yaml(card))
-        age_v = next(v for v in parsed["input"] if v["type"] == "dicom_patient_age")
-        assert age_v["severity"] == "warning"
 
 
 # ---------------------------------------------------------------------------
@@ -381,37 +248,23 @@ class TestModelCardToYaml:
 # ---------------------------------------------------------------------------
 
 class TestModelCardToSpec:
-    def test_returns_spec_with_input_validators(self):
+    def test_returns_spec_with_validators(self):
         from healthcare_ai_guardrails.config import Spec
 
-        card = _sample_model_card()
-        spec = model_card_to_spec(card)
+        spec = model_card_to_spec(_sample_model_card())
         assert isinstance(spec, Spec)
         assert len(spec.input_validators) > 0
-
-    def test_output_validators_empty(self):
-        card = _sample_model_card()
-        spec = model_card_to_spec(card)
         assert spec.output_validators == []
 
-    def test_modality_validator_has_ct(self):
-        from healthcare_ai_guardrails.validators.dicom import DICOMModalityCheck
+    def test_validator_details(self):
+        from healthcare_ai_guardrails.validators.dicom import DICOMModalityCheck, DICOMPatientAgeCheck
 
-        card = _sample_model_card()
-        spec = model_card_to_spec(card)
-        modality_validators = [v for v in spec.input_validators if isinstance(v, DICOMModalityCheck)]
-        assert len(modality_validators) == 1
-        assert "CT" in modality_validators[0].allowed_modalities
+        spec = model_card_to_spec(_sample_model_card())
+        modality_v = next(v for v in spec.input_validators if isinstance(v, DICOMModalityCheck))
+        assert "CT" in modality_v.allowed_modalities
 
-    def test_age_validator_bounds(self):
-        from healthcare_ai_guardrails.validators.dicom import DICOMPatientAgeCheck
-
-        card = _sample_model_card()
-        spec = model_card_to_spec(card)
-        age_validators = [v for v in spec.input_validators if isinstance(v, DICOMPatientAgeCheck)]
-        assert len(age_validators) == 1
-        assert age_validators[0].min_years == 18.0
-        assert age_validators[0].max_years == 75.0
+        age_v = next(v for v in spec.input_validators if isinstance(v, DICOMPatientAgeCheck))
+        assert age_v.min_years == 18.0 and age_v.max_years == 75.0
 
 
 # ---------------------------------------------------------------------------
@@ -419,22 +272,15 @@ class TestModelCardToSpec:
 # ---------------------------------------------------------------------------
 
 class TestLoadModelCard:
-    def test_loads_json_from_file(self, tmp_path: Path):
-        card = _sample_model_card()
+    def test_loads_json_file(self, tmp_path: Path):
         p = tmp_path / "model_card.json"
-        p.write_text(json.dumps(card), encoding="utf-8")
-        loaded = load_model_card(p)
-        assert loaded["task"] == "Segmentation"
+        p.write_text(json.dumps(_sample_model_card()), encoding="utf-8")
+        # accepts both Path and str
+        assert load_model_card(p)["task"] == "Segmentation"
+        assert isinstance(load_model_card(str(p)), dict)
 
     def test_raises_on_non_object_json(self, tmp_path: Path):
         p = tmp_path / "bad.json"
         p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
         with pytest.raises(ValueError, match="JSON object"):
             load_model_card(p)
-
-    def test_accepts_string_path(self, tmp_path: Path):
-        card = _sample_model_card()
-        p = tmp_path / "model_card.json"
-        p.write_text(json.dumps(card), encoding="utf-8")
-        loaded = load_model_card(str(p))
-        assert isinstance(loaded, dict)

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -17,6 +17,7 @@ from healthcare_ai_guardrails.model_card import (
     _parse_sex,
     _parse_slice_thickness,
     load_model_card,
+    model_card_to_extraction_summary,
     model_card_to_spec,
     model_card_to_yaml,
 )
@@ -319,3 +320,63 @@ class TestLoadModelCard:
         p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
         with pytest.raises(ValueError, match="JSON object"):
             load_model_card(p)
+
+
+# ---------------------------------------------------------------------------
+# model_card_to_extraction_summary
+# ---------------------------------------------------------------------------
+
+
+class TestModelCardToExtractionSummary:
+    def test_extracted_fields_from_full_card(self):
+        summary = model_card_to_extraction_summary(_sample_model_card())
+        extracted = summary["extracted"]
+        assert extracted["modalities"] == ["CT"]
+        assert extracted["age_range"] == [18.0, 75.0]
+        assert set(extracted["sex"]) == {"M", "F"}
+        assert "HFS" in extracted["patient_positions"]
+        assert extracted["slice_thickness_mm"] == [1.0, 3.0]
+        assert extracted["kvp"] == [120.0, 120.0]
+
+    def test_skipped_fields_empty_card(self):
+        card: Dict[str, Any] = {
+            "technical_specifications": {"model_inputs": []},
+            "training_data": {},
+        }
+        summary = model_card_to_extraction_summary(card)
+        assert "modalities" in summary["skipped_fields"]
+        assert "age" in summary["skipped_fields"]
+
+    def test_return_structure(self):
+        summary = model_card_to_extraction_summary(_sample_model_card())
+        assert "extracted" in summary
+        assert "skipped_fields" in summary
+        assert isinstance(summary["extracted"], dict)
+        assert isinstance(summary["skipped_fields"], list)
+
+
+# ---------------------------------------------------------------------------
+# Integration: load → generate spec → verify validators
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_load_generate_spec_roundtrip(self, tmp_path: Path):
+        """Full pipeline: save JSON file, load it, generate Spec, verify validators."""
+        p = tmp_path / "card.json"
+        p.write_text(json.dumps(_sample_model_card()), encoding="utf-8")
+        card = load_model_card(p)
+        spec = model_card_to_spec(card)
+        # At minimum: modality + age + sex + position + slice thickness + kvp
+        assert len(spec.input_validators) >= 4
+        assert spec.output_validators == []
+
+    def test_load_generate_yaml_is_valid_yaml(self, tmp_path: Path):
+        p = tmp_path / "card.json"
+        p.write_text(json.dumps(_sample_model_card()), encoding="utf-8")
+        card = load_model_card(p)
+        raw_yaml = model_card_to_yaml(card)
+        parsed = yaml.safe_load(raw_yaml)
+        assert isinstance(parsed, dict)
+        assert "input" in parsed
+        assert len(parsed["input"]) >= 4

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -13,7 +13,9 @@ from healthcare_ai_guardrails.model_card import (
     _parse_age_range,
     _parse_kvp,
     _parse_modalities,
+    _parse_output_modalities,
     _parse_patient_positions,
+    _parse_scanner_models,
     _parse_sex,
     _parse_slice_thickness,
     load_model_card,
@@ -45,6 +47,7 @@ def _sample_model_card() -> Dict[str, Any]:
                     "source": "model_inputs",
                     "patient_positioning": "HFS",
                     "scan_acquisition_parameters": "kVp: 120, slice thickness: 1-3mm",
+                    "scanner_model": "Siemens SOMATOM Definition AS+, GE Discovery CT750 HD",
                     "image_resolution": "512x512",
                 }
             ],
@@ -140,6 +143,50 @@ class TestParseModalities:
     def test_deduplication(self):
         card = {"technical_specifications": {"model_inputs": ["CT", "CT"]}}
         assert _parse_modalities(card) == ["CT"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_output_modalities
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutputModalities:
+    def test_standard_code(self):
+        card = {"technical_specifications": {"model_outputs": ["RTSTRUCT"]}}
+        assert _parse_output_modalities(card) == ["RTSTRUCT"]
+
+    def test_normalise_aliases(self):
+        card = {"technical_specifications": {"model_outputs": ["MRI"]}}
+        assert _parse_output_modalities(card) == ["MR"]
+
+    def test_empty_list(self):
+        card = {"technical_specifications": {"model_outputs": []}}
+        assert _parse_output_modalities(card) == []
+
+    def test_missing_key(self):
+        assert _parse_output_modalities({}) == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_scanner_models
+# ---------------------------------------------------------------------------
+
+
+class TestParseScannerModels:
+    def test_single_model(self):
+        assert _parse_scanner_models("Siemens SOMATOM Definition AS+") == [
+            "Siemens SOMATOM Definition AS+"
+        ]
+
+    def test_comma_separated(self):
+        result = _parse_scanner_models(
+            "Siemens SOMATOM Definition AS+, GE Discovery CT750 HD"
+        )
+        assert result == ["Siemens SOMATOM Definition AS+", "GE Discovery CT750 HD"]
+
+    def test_empty(self):
+        assert _parse_scanner_models("") == []
+        assert _parse_scanner_models("   ") == []
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +308,32 @@ class TestModelCardToYaml:
             "dicom_kvp",
         }.issubset(types)
 
+    def test_output_modality_validator_in_output_section(self):
+        parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
+        assert "output" in parsed
+        assert len(parsed["output"]) == 1
+        assert parsed["output"][0]["type"] == "dicom_modality"
+        assert "RTSTRUCT" in parsed["output"][0]["allowed"]
+
+    def test_scanner_model_validator_present(self):
+        parsed = yaml.safe_load(model_card_to_yaml(_sample_model_card()))
+        scanner_v = next(
+            (v for v in parsed["input"] if v["type"] == "dicom_generic_value_in_list"),
+            None,
+        )
+        assert scanner_v is not None
+        assert scanner_v["tag"] == "ManufacturerModelName"
+        assert "Siemens SOMATOM Definition AS+" in scanner_v["allowed_values"]
+
+    def test_skipped_fields_appear_in_comment(self):
+        card: Dict[str, Any] = {
+            "technical_specifications": {"model_inputs": []},
+            "training_data": {},
+        }
+        raw = model_card_to_yaml(card)
+        assert "Fields not extracted" in raw
+        assert "modalities" in raw
+
     def test_empty_training_data_produces_minimal_spec(self):
         card: Dict[str, Any] = {
             "technical_specifications": {"model_inputs": []},
@@ -282,7 +355,8 @@ class TestModelCardToSpec:
         spec = model_card_to_spec(_sample_model_card())
         assert isinstance(spec, Spec)
         assert len(spec.input_validators) > 0
-        assert spec.output_validators == []
+        # RTSTRUCT in model_outputs → output modality validator
+        assert len(spec.output_validators) == 1
 
     def test_validator_details(self):
         from healthcare_ai_guardrails.validators.dicom import (
@@ -337,6 +411,8 @@ class TestModelCardToExtractionSummary:
         assert "HFS" in extracted["patient_positions"]
         assert extracted["slice_thickness_mm"] == [1.0, 3.0]
         assert extracted["kvp"] == [120.0, 120.0]
+        assert extracted["output_modalities"] == ["RTSTRUCT"]
+        assert "Siemens SOMATOM Definition AS+" in extracted["scanner_models"]
 
     def test_skipped_fields_empty_card(self):
         card: Dict[str, Any] = {
@@ -367,9 +443,10 @@ class TestIntegration:
         p.write_text(json.dumps(_sample_model_card()), encoding="utf-8")
         card = load_model_card(p)
         spec = model_card_to_spec(card)
-        # At minimum: modality + age + sex + position + slice thickness + kvp
+        # modality + age + sex + position + slice thickness + kvp + scanner model
         assert len(spec.input_validators) >= 4
-        assert spec.output_validators == []
+        # RTSTRUCT in model_outputs → output modality validator
+        assert len(spec.output_validators) == 1
 
     def test_load_generate_yaml_is_valid_yaml(self, tmp_path: Path):
         p = tmp_path / "card.json"
@@ -379,4 +456,6 @@ class TestIntegration:
         parsed = yaml.safe_load(raw_yaml)
         assert isinstance(parsed, dict)
         assert "input" in parsed
+        assert "output" in parsed
         assert len(parsed["input"]) >= 4
+        assert len(parsed["output"]) == 1

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -94,10 +94,17 @@ class TestParseSex:
     def test_male_and_female_keywords(self):
         assert _parse_sex("Male and Female") == ["M", "F"]
 
-    @pytest.mark.parametrize("text", ["both sexes", "All genders"])
+    @pytest.mark.parametrize("text", ["both sexes", "All genders", "all sexes"])
     def test_both_or_all(self, text):
         result = _parse_sex(text)
         assert "M" in result and "F" in result
+
+    @pytest.mark.parametrize(
+        "text,expected", [("all male", ["M"]), ("all female", ["F"])]
+    )
+    def test_all_plus_single_sex_not_both(self, text, expected):
+        """'all male'/'all female' must not be treated as both sexes."""
+        assert _parse_sex(text) == expected
 
     def test_shorthand(self):
         assert _parse_sex("M/F") == ["M", "F"]
@@ -143,6 +150,17 @@ class TestParseModalities:
     def test_deduplication(self):
         card = {"technical_specifications": {"model_inputs": ["CT", "CT"]}}
         assert _parse_modalities(card) == ["CT"]
+
+    def test_compound_modality_split(self):
+        """PET/CT must produce both PT and CT, not drop CT."""
+        card = {"technical_specifications": {"model_inputs": ["PET/CT"]}}
+        result = _parse_modalities(card)
+        assert set(result) == {"PT", "CT"}
+
+    def test_xray_ct_split(self):
+        card = {"technical_specifications": {"model_inputs": ["XRAY/CT"]}}
+        result = _parse_modalities(card)
+        assert set(result) == {"DX", "CT"}
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +359,21 @@ class TestModelCardToYaml:
         }
         parsed = yaml.safe_load(model_card_to_yaml(card))
         assert parsed["input"] == []
+
+    def test_newline_in_model_name_does_not_break_yaml(self):
+        """A newline in the model name must not create a multi-line YAML comment."""
+        card: Dict[str, Any] = {
+            "model_basic_information": {"name": "Evil\nModel"},
+            "technical_specifications": {"model_inputs": []},
+            "training_data": {},
+        }
+        raw = model_card_to_yaml(card)
+        # Every line that starts with "#" is still a comment
+        for line in raw.splitlines():
+            if line.startswith("#"):
+                assert "\n" not in line
+        # Must still parse as valid YAML
+        assert yaml.safe_load(raw) is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds `model_card.py` module that parses an exported RT-AI-Model-Card JSON
(https://github.com/MIRO-UCLouvain/RT-AI-Model-Card) and automatically
generates a guardrail YAML spec enforcing the training distribution at
inference time. No new dependencies required — the JSON export is parsed
directly.

Extracted fields → guardrail validators:
- `technical_specifications.model_inputs` → `dicom_modality` (error)
- `training_data.age` (free text, regex) → `dicom_patient_age` (warning)
- `training_data.sex` (free text, keyword) → `dicom_patient_sex` (warning)
- `patient_positioning` per modality → `dicom_patient_position` (warning)
- `scan_acquisition_parameters` → `dicom_slice_thickness` + `dicom_kvp` (warning)

Fields that cannot be reliably parsed are silently skipped.

Public API additions:
- `load_model_card(path)` — load model card JSON from file
- `model_card_to_yaml(card)` — generate guardrail YAML string
- `model_card_to_spec(card)` — generate Spec object directly

CLI additions:
- `hc-guardrails --from-model-card model.json --generate-spec [out.yaml]`
- `hc-guardrails --from-model-card model.json data.dcm --mode input`

MCP tool addition:
- `generate_spec_from_model_card(model_card_json)` — returns YAML + extraction summary

